### PR TITLE
Reloading of device list

### DIFF
--- a/app/src/main/java/io/github/domi04151309/home/MainActivity.kt
+++ b/app/src/main/java/io/github/domi04151309/home/MainActivity.kt
@@ -49,7 +49,7 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
     private var hueCurrentIcon: Int = 0
     private var tasmotaPosition: Int = 0
     private var level = "one"
-    private var reset = false
+    private var reset : Boolean = false
     private val updateHandler = UpdateHandler()
     private var canReceiveRequest = false
 
@@ -509,6 +509,11 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
     override fun onStart() {
         super.onStart()
         canReceiveRequest = true
+    }
+
+    override fun onResume() {
+        super.onResume()
+        canReceiveRequest = true
         if(reset) {
             navView!!.setCheckedItem(R.id.nav_devices)
             loadDevices()
@@ -519,10 +524,5 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
     override fun onStop() {
         super.onStop()
         canReceiveRequest = false
-        if(reset) {
-            navView!!.setCheckedItem(R.id.nav_devices)
-            loadDevices()
-            reset = false
-        }
     }
 }

--- a/app/src/main/java/io/github/domi04151309/home/MainActivity.kt
+++ b/app/src/main/java/io/github/domi04151309/home/MainActivity.kt
@@ -509,16 +509,12 @@ class MainActivity : AppCompatActivity(), NavigationView.OnNavigationItemSelecte
     override fun onStart() {
         super.onStart()
         canReceiveRequest = true
-    }
-
-    override fun onResume() {
-        super.onResume()
-        canReceiveRequest = true
         if(reset) {
             navView!!.setCheckedItem(R.id.nav_devices)
             loadDevices()
             reset = false
         }
+
     }
 
     override fun onStop() {


### PR DESCRIPTION
The reloading of the device list depends on the variable reset. In the onStop state of main activity, this value was set to false. Consequently, after creating a new device or removing an existing device and returning to main screen resulted in an outdated device list. 

Additionally, I moved the check from onStart to onResume to prevent a possible edge case if an activity is only paused instead of completely stopped. 