### PR TITLE
Add mDNS discovery for SimpleHome devices

### DIFF
--- a/app/src/main/java/io/github/domi04151309/home/activities/SearchDevicesActivity.kt
+++ b/app/src/main/java/io/github/domi04151309/home/activities/SearchDevicesActivity.kt
@@ -31,7 +31,8 @@ class SearchDevicesActivity : AppCompatActivity(), RecyclerViewHelperInterface {
     private lateinit var adapter: DeviceDiscoveryListAdapter
     private lateinit var devices: Devices
     private lateinit var nsdManager: NsdManager
-    private lateinit var discoveryListener: NsdManager.DiscoveryListener
+    private lateinit var discoveryListenerHttp: NsdManager.DiscoveryListener
+    private lateinit var discoveryListenerSimpleHome: NsdManager.DiscoveryListener
     private lateinit var resolveListener: NsdManager.ResolveListener
     private var resolveListenerBusy = AtomicBoolean(false)
     private var pendingNsdServices = ConcurrentLinkedQueue<NsdServiceInfo>()
@@ -133,13 +134,23 @@ class SearchDevicesActivity : AppCompatActivity(), RecyclerViewHelperInterface {
         resolveListener =  object : NsdManager.ResolveListener {
             override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
                 val gen = serviceInfo.attributes["gen"]
+                val url = serviceInfo.attributes["url"]
                 runOnUiThread {
-                    adapter.add(SimpleListItem(
-                        title = serviceInfo.serviceName,
-                        summary = serviceInfo.host.hostAddress,
-                        hidden = "Shelly Gen ${if (gen == null) "1" else gen?.decodeToString()}#Lamp",
-                        icon = R.drawable.ic_device_lamp
-                    ))
+                    if (serviceInfo.serviceType.equals("._simplehome._tcp")) {
+                        adapter.add(SimpleListItem(
+                                title = serviceInfo.serviceName,
+                                summary = if (url != null) url.decodeToString() else serviceInfo.host.hostAddress,
+                                hidden = "SimpleHome API#Raspberry Pi",
+                                icon = R.drawable.ic_device_raspberry_pi
+                        ))
+                    } else {
+                        adapter.add(SimpleListItem(
+                                title = serviceInfo.serviceName,
+                                summary = serviceInfo.host.hostAddress,
+                                hidden = "Shelly Gen ${if (gen == null) "1" else gen?.decodeToString()}#Lamp",
+                                icon = R.drawable.ic_device_lamp
+                        ))
+                    }
                 }
                 resolveNextInQueue()
             }
@@ -149,7 +160,7 @@ class SearchDevicesActivity : AppCompatActivity(), RecyclerViewHelperInterface {
             }
         }
 
-        discoveryListener = object : NsdManager.DiscoveryListener {
+        class DnsDiscoveryListener : NsdManager.DiscoveryListener {
             override fun onStartDiscoveryFailed(p0: String?, p1: Int) {
                 nsdManager.stopServiceDiscovery(this)
             }
@@ -160,8 +171,8 @@ class SearchDevicesActivity : AppCompatActivity(), RecyclerViewHelperInterface {
 
             override fun onServiceFound(service: NsdServiceInfo) {
                 val lowService = service.serviceName.lowercase()
-                if (lowService.startsWith("shelly")
-                        && !lowService.startsWith("shellybutton1")
+                if ((lowService.startsWith("shelly") && !lowService.startsWith("shellybutton1"))
+                        || service.serviceType.equals("_simplehome._tcp.")
                 ) {
                     if (resolveListenerBusy.compareAndSet(false, true))
                         nsdManager.resolveService(service, resolveListener)
@@ -181,7 +192,12 @@ class SearchDevicesActivity : AppCompatActivity(), RecyclerViewHelperInterface {
             override fun onDiscoveryStarted(p0: String?) { }
             override fun onDiscoveryStopped(p0: String?) { }
         }
-        nsdManager.discoverServices("_http._tcp", NsdManager.PROTOCOL_DNS_SD, discoveryListener)
+
+        discoveryListenerHttp = DnsDiscoveryListener()
+        nsdManager.discoverServices("_http._tcp", NsdManager.PROTOCOL_DNS_SD, discoveryListenerHttp)
+
+        discoveryListenerSimpleHome = DnsDiscoveryListener()
+        nsdManager.discoverServices("_simplehome._tcp", NsdManager.PROTOCOL_DNS_SD, discoveryListenerSimpleHome)
     }
 
     private fun resolveNextInQueue() {
@@ -215,6 +231,7 @@ class SearchDevicesActivity : AppCompatActivity(), RecyclerViewHelperInterface {
 
     override fun onStop() {
         super.onStop()
-        nsdManager.stopServiceDiscovery(discoveryListener)
+        nsdManager.stopServiceDiscovery(discoveryListenerHttp)
+        nsdManager.stopServiceDiscovery(discoveryListenerSimpleHome)
     }
 }


### PR DESCRIPTION
With that in place, devices can use avahi-daemon to get their
SimpleHome API services automatically discovered by HomeApp.

Example avahi daemon service file:
----
```
<?xml version="1.0"?>
<service-group>
  <name>Lamps for HomeApp</name>
  <service protocol="ipv4">
    <type>_simplehome._tcp</type>
    <port>80</port>
    <txt-record>url=http://simpleapi-homeapp.example.org/</txt-record>
  </service>
</service-group>
```
----

The TXT record with "url" property is optional.
If not specified, the IP address of the server will be used by HomeApp.

Specifying the url lets you announce multiple services on the same host.

![Screenshot_20211202-213314_Home](https://user-images.githubusercontent.com/59036/144500332-7fc3ec42-f51b-444a-9bc4-a3d1b31ad7d3.png)