### PR TITLE
Show customized shelly device names in device discovery

### DIFF
--- a/app/src/main/java/io/github/domi04151309/home/activities/SearchDevicesActivity.kt
+++ b/app/src/main/java/io/github/domi04151309/home/activities/SearchDevicesActivity.kt
@@ -150,7 +150,7 @@ class SearchDevicesActivity : AppCompatActivity(), RecyclerViewHelperInterface {
                             state = devices.addressExists(serviceInfo.host.hostAddress)
                         ))
                     } else {
-                        adapter.add(ListViewItem(
+                        val pos = adapter.add(ListViewItem(
                             title = serviceInfo.serviceName,
                             summary = serviceInfo.host.hostAddress,
                             hidden = "Shelly Gen ${serviceInfo.attributes["gen"]?.decodeToString() ?: "1"}#Lamp",
@@ -163,9 +163,7 @@ class SearchDevicesActivity : AppCompatActivity(), RecyclerViewHelperInterface {
                                 "http://" + serviceInfo.host.hostAddress + "/",
                                 serviceInfo.attributes["gen"]?.decodeToString()?.toInt() ?: 1
                             ) { name ->
-                                if (name.isNotEmpty()) {
-                                    adapter.changeTitle(serviceInfo.host.hostAddress, name)
-                                }
+                                if (name.isNotEmpty()) adapter.changeTitle(pos, name)
                             }
                         )
                     }

--- a/app/src/main/java/io/github/domi04151309/home/activities/SearchDevicesActivity.kt
+++ b/app/src/main/java/io/github/domi04151309/home/activities/SearchDevicesActivity.kt
@@ -51,6 +51,7 @@ class SearchDevicesActivity : AppCompatActivity(), RecyclerViewHelperInterface {
         )), this)
         devices = Devices(this)
         val addresses = mutableListOf<String>()
+        val queue = Volley.newRequestQueue(this)
 
         recyclerView.layoutManager = LinearLayoutManager(this)
         recyclerView.adapter = adapter
@@ -136,7 +137,6 @@ class SearchDevicesActivity : AppCompatActivity(), RecyclerViewHelperInterface {
 
 
         nsdManager = (getSystemService(NSD_SERVICE) as NsdManager)
-        val queue = Volley.newRequestQueue(this)
         resolveListener =  object : NsdManager.ResolveListener {
             override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
                 runOnUiThread {

--- a/app/src/main/java/io/github/domi04151309/home/activities/SearchDevicesActivity.kt
+++ b/app/src/main/java/io/github/domi04151309/home/activities/SearchDevicesActivity.kt
@@ -14,11 +14,13 @@ import androidx.appcompat.app.AlertDialog
 import android.widget.TextView
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.android.volley.toolbox.Volley
 import io.github.domi04151309.home.R
 import io.github.domi04151309.home.adapters.DeviceDiscoveryListAdapter
 import io.github.domi04151309.home.data.DeviceItem
 import io.github.domi04151309.home.data.ListViewItem
 import io.github.domi04151309.home.helpers.Devices
+import io.github.domi04151309.home.helpers.ShellyAPI
 import io.github.domi04151309.home.helpers.Theme
 import io.github.domi04151309.home.interfaces.RecyclerViewHelperInterface
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -134,6 +136,7 @@ class SearchDevicesActivity : AppCompatActivity(), RecyclerViewHelperInterface {
 
 
         nsdManager = (getSystemService(NSD_SERVICE) as NsdManager)
+        val queue = Volley.newRequestQueue(this)
         resolveListener =  object : NsdManager.ResolveListener {
             override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
                 runOnUiThread {
@@ -154,6 +157,17 @@ class SearchDevicesActivity : AppCompatActivity(), RecyclerViewHelperInterface {
                             icon = R.drawable.ic_device_lamp,
                             state = devices.addressExists(serviceInfo.host.hostAddress)
                         ))
+
+                        queue.add(
+                            ShellyAPI.loadName(
+                                "http://" + serviceInfo.host.hostAddress + "/",
+                                serviceInfo.attributes["gen"]?.decodeToString()?.toInt() ?: 1
+                            ) { name ->
+                                if (name.isNotEmpty()) {
+                                    adapter.changeTitle(serviceInfo.host.hostAddress, name)
+                                }
+                            }
+                        )
                     }
                 }
                 resolveNextInQueue()

--- a/app/src/main/java/io/github/domi04151309/home/adapters/DeviceDiscoveryListAdapter.kt
+++ b/app/src/main/java/io/github/domi04151309/home/adapters/DeviceDiscoveryListAdapter.kt
@@ -52,6 +52,16 @@ class DeviceDiscoveryListAdapter(
         notifyItemChanged(i)
     }
 
+    fun changeTitle(summary: String, newTitle: String) {
+        for (i in 0 until items.size) {
+            if (items[i].summary.equals(summary)) {
+                items[i].title = newTitle
+                notifyItemChanged(i)
+                break
+            }
+        }
+    }
+
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val drawable: ImageView = view.findViewById(R.id.drawable)
         val title: TextView = view.findViewById(R.id.title)

--- a/app/src/main/java/io/github/domi04151309/home/adapters/DeviceDiscoveryListAdapter.kt
+++ b/app/src/main/java/io/github/domi04151309/home/adapters/DeviceDiscoveryListAdapter.kt
@@ -42,9 +42,10 @@ class DeviceDiscoveryListAdapter(
         return items.size
     }
 
-    fun add(item: ListViewItem) {
+    fun add(item: ListViewItem) : Int {
         items.add(item)
         notifyItemInserted(items.size - 1)
+        return items.size - 1
     }
 
     fun changeState(i: Int, state: Boolean) {
@@ -52,14 +53,9 @@ class DeviceDiscoveryListAdapter(
         notifyItemChanged(i)
     }
 
-    fun changeTitle(summary: String, newTitle: String) {
-        for (i in 0 until items.size) {
-            if (items[i].summary.equals(summary)) {
-                items[i].title = newTitle
-                notifyItemChanged(i)
-                break
-            }
-        }
+    fun changeTitle(i: Int, title: String) {
+        items[i].title = title
+        notifyItemChanged(i)
     }
 
     class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {

--- a/app/src/main/java/io/github/domi04151309/home/data/ListViewItem.kt
+++ b/app/src/main/java/io/github/domi04151309/home/data/ListViewItem.kt
@@ -1,9 +1,9 @@
 package io.github.domi04151309.home.data
 
 data class ListViewItem(
-        val title: String = "",
-        var summary: String = "",
-        var hidden: String = "",
-        var icon: Int = 0,
-        var state: Boolean? = null
+    var title: String = "",
+    var summary: String = "",
+    var hidden: String = "",
+    var icon: Int = 0,
+    var state: Boolean? = null
 )

--- a/app/src/main/java/io/github/domi04151309/home/helpers/ShellyAPI.kt
+++ b/app/src/main/java/io/github/domi04151309/home/helpers/ShellyAPI.kt
@@ -96,24 +96,20 @@ class ShellyAPI(private val c: Context, deviceId: String, private val version: I
          * Detect the name of the shelly device during discovery
          */
         fun loadName(url: String, version: Int, listener: Response.Listener<String>): JsonObjectRequest {
-            if (version == 1) {
-                return JsonObjectRequest(
+            return if (version == 1) {
+                JsonObjectRequest(
                     url + "settings",
                     { statusResponse ->
-                        val name = statusResponse.optString("name")
-                        listener.onResponse(name)
-                    },
-                    {}
+                        listener.onResponse(statusResponse.optString("name"))
+                    }, {}
                 )
             } else {
                 // "/shelly" is available without password
-                return JsonObjectRequest(
+                JsonObjectRequest(
                     url + "shelly",
                     { statusResponse ->
-                        val name = statusResponse.optString("name")
-                        listener.onResponse(name)
-                    },
-                    {}
+                        listener.onResponse(statusResponse.optString("name"))
+                    }, {}
                 )
             }
         }

--- a/app/src/main/java/io/github/domi04151309/home/helpers/ShellyAPI.kt
+++ b/app/src/main/java/io/github/domi04151309/home/helpers/ShellyAPI.kt
@@ -3,6 +3,7 @@ package io.github.domi04151309.home.helpers
 import android.content.Context
 import android.util.Log
 import com.android.volley.Request
+import com.android.volley.Response
 import com.android.volley.toolbox.JsonObjectRequest
 import com.android.volley.toolbox.Volley
 import io.github.domi04151309.home.custom.JsonObjectRequestAuth
@@ -88,5 +89,33 @@ class ShellyAPI(private val c: Context, deviceId: String, private val version: I
             else -> null
         }
         queue.add(jsonObjectRequest)
+    }
+
+    companion object {
+        /**
+         * Detect the name of the shelly device during discovery
+         */
+        fun loadName(url: String, version: Int, listener: Response.Listener<String>): JsonObjectRequest {
+            if (version == 1) {
+                return JsonObjectRequest(
+                    url + "settings",
+                    { statusResponse ->
+                        val name = statusResponse.optString("name")
+                        listener.onResponse(name)
+                    },
+                    {}
+                )
+            } else {
+                // "/shelly" is available without password
+                return JsonObjectRequest(
+                    url + "shelly",
+                    { statusResponse ->
+                        val name = statusResponse.optString("name")
+                        listener.onResponse(name)
+                    },
+                    {}
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
.. so we do not have to see "ShellyPlus1-DEADBEEFCAFE" but get the self-defined
names. Shelly v1 devices all have this, v2 only from firmware 0.9+

Related: https://github.com/Domi04151309/HomeApp/issues/27

![Screenshot_20211208-201203_Home](https://user-images.githubusercontent.com/59036/145270274-27c3d2d8-6433-4890-9512-4c3cb27f775a.png)