### PR TITLE
ESP Easy support (sensors + relays)

### DIFF
--- a/app/src/main/java/io/github/domi04151309/home/activities/MainActivity.kt
+++ b/app/src/main/java/io/github/domi04151309/home/activities/MainActivity.kt
@@ -68,9 +68,7 @@ class MainActivity : AppCompatActivity(), RecyclerViewHelperInterface {
         if (compoundButton.isPressed) {
             val view = (compoundButton.parent as ViewGroup)
             val gpioId = view.findViewById<TextView>(R.id.hidden).text.toString()
-            if (gpioId.isEmpty()) {
-                return@OnCheckedChangeListener
-            }
+            if (gpioId.isEmpty()) return@OnCheckedChangeListener
 
             view.findViewById<TextView>(R.id.summary).text = resources.getString(
                 if (newState) R.string.shelly_switch_summary_on

--- a/app/src/main/java/io/github/domi04151309/home/helpers/EspEasyAPI.kt
+++ b/app/src/main/java/io/github/domi04151309/home/helpers/EspEasyAPI.kt
@@ -1,0 +1,50 @@
+package io.github.domi04151309.home.helpers
+
+import android.content.Context
+import android.util.Log
+import com.android.volley.Request
+import com.android.volley.toolbox.JsonObjectRequest
+import com.android.volley.toolbox.Volley
+import io.github.domi04151309.home.custom.JsonObjectRequestAuth
+import io.github.domi04151309.home.data.ListViewItem
+import io.github.domi04151309.home.data.RequestCallbackObject
+import kotlin.collections.ArrayList
+
+class EspEasyAPI(private val c: Context, deviceId: String) {
+
+    private val selectedDevice = deviceId
+    private val url = Devices(c).getDeviceById(deviceId).address
+    private val queue = Volley.newRequestQueue(c)
+
+    interface RequestCallBack {
+        fun onInfoLoaded(holder: RequestCallbackObject<ArrayList<ListViewItem>>)
+    }
+
+    fun loadInfo(callback: RequestCallBack) {
+        val jsonObjectRequest = JsonObjectRequest(
+            Request.Method.GET, url + "json", null,
+            { infoResponse ->
+                val parser = EspEasyAPIParser(url, c.resources)
+                callback.onInfoLoaded(RequestCallbackObject(
+                    c,
+                    parser.parseInfo(infoResponse),
+                    selectedDevice
+                ))
+            },
+            { error ->
+                callback.onInfoLoaded(RequestCallbackObject(c, null, selectedDevice, Global.volleyError(c, error)))
+            }
+        )
+        queue.add(jsonObjectRequest)
+    }
+
+    fun changeSwitchState(gpioId: Int, newState: Boolean) {
+        val switchUrl = url + "control?cmd=GPIO," + gpioId + "," + (if (newState) "1" else "0")
+        val jsonObjectRequest = JsonObjectRequest(
+            switchUrl,
+            { },
+            { e -> Log.e(Global.LOG_TAG, e.toString()) }
+        )
+        queue.add(jsonObjectRequest)
+    }
+}

--- a/app/src/main/java/io/github/domi04151309/home/helpers/EspEasyAPI.kt
+++ b/app/src/main/java/io/github/domi04151309/home/helpers/EspEasyAPI.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import com.android.volley.Request
 import com.android.volley.toolbox.JsonObjectRequest
 import com.android.volley.toolbox.Volley
-import io.github.domi04151309.home.custom.JsonObjectRequestAuth
 import io.github.domi04151309.home.data.ListViewItem
 import io.github.domi04151309.home.data.RequestCallbackObject
 import kotlin.collections.ArrayList
@@ -24,10 +23,9 @@ class EspEasyAPI(private val c: Context, deviceId: String) {
         val jsonObjectRequest = JsonObjectRequest(
             Request.Method.GET, url + "json", null,
             { infoResponse ->
-                val parser = EspEasyAPIParser(url, c.resources)
                 callback.onInfoLoaded(RequestCallbackObject(
                     c,
-                    parser.parseInfo(infoResponse),
+                    EspEasyAPIParser(url, c.resources).parseInfo(infoResponse),
                     selectedDevice
                 ))
             },

--- a/app/src/main/java/io/github/domi04151309/home/helpers/EspEasyAPIParser.kt
+++ b/app/src/main/java/io/github/domi04151309/home/helpers/EspEasyAPIParser.kt
@@ -44,7 +44,7 @@ class EspEasyAPIParser(val url: String, val resources: Resources) {
             "Environment - BMx280" -> {
                 taskIcons += R.drawable.ic_device_thermometer
                 taskIcons += R.drawable.ic_humidity
-                taskIcons += R.drawable.ic_info
+                taskIcons += R.drawable.ic_gauge
             }
             "Environment - DHT11/12/22  SONOFF2301/7021" -> {
                 taskIcons += R.drawable.ic_device_thermometer
@@ -63,7 +63,7 @@ class EspEasyAPIParser(val url: String, val resources: Resources) {
                 val suffix = when (taskIcons[taskId]) {
                     R.drawable.ic_device_thermometer -> " °C"
                     R.drawable.ic_humidity -> " %"
-                    R.drawable.ic_info -> " hPa"
+                    R.drawable.ic_gauge -> " hPa"
                     else -> ""
                 }
                 listItems += ListViewItem(

--- a/app/src/main/java/io/github/domi04151309/home/helpers/EspEasyAPIParser.kt
+++ b/app/src/main/java/io/github/domi04151309/home/helpers/EspEasyAPIParser.kt
@@ -56,7 +56,7 @@ class EspEasyAPIParser(val url: String, val resources: Resources) {
         }
 
         val taskName = currentSensor.getString("TaskName")
-        for (taskId in 0 until taskIcons.size) {
+        for (taskId in taskIcons.indices) {
             val currentTask = currentSensor.getJSONArray("TaskValues").getJSONObject(taskId)
             val currentValue = currentTask.getString("Value")
             if (!currentValue.equals("nan")) {
@@ -81,11 +81,11 @@ class EspEasyAPIParser(val url: String, val resources: Resources) {
                 val currentState = currentSensor.getJSONArray("TaskValues").getJSONObject(0).getInt("Value") > 0
                 var taskName =currentSensor.getString("TaskName")
                 var gpioId = ""
-                val gpioFinder = Regex("~GPIO~([0-9]+)$")
+                val gpioFinder = Regex("~GPIO~(?:[0-9]+)$")
                 val matchResult = gpioFinder.find(taskName)
                 if (matchResult != null && matchResult.groupValues.size > 1) {
                     gpioId = matchResult.groupValues[1]
-                    taskName = taskName.replace("~GPIO~" + gpioId, "")
+                    taskName = taskName.replace("~GPIO~$gpioId", "")
                 }
                 listItems += ListViewItem(
                     title = taskName,

--- a/app/src/main/java/io/github/domi04151309/home/helpers/EspEasyAPIParser.kt
+++ b/app/src/main/java/io/github/domi04151309/home/helpers/EspEasyAPIParser.kt
@@ -1,0 +1,103 @@
+package io.github.domi04151309.home.helpers
+
+import android.content.res.Resources
+import io.github.domi04151309.home.R
+import io.github.domi04151309.home.data.ListViewItem
+import org.json.JSONArray
+import org.json.JSONObject
+
+class EspEasyAPIParser(val url: String, val resources: Resources) {
+
+    fun parseInfo(info: JSONObject): ArrayList<ListViewItem> {
+        val listItems = arrayListOf<ListViewItem>()
+
+        //sensors
+        val sensors = info.optJSONArray("Sensors") ?: JSONArray()
+        for (sensorId in 0 until sensors.length()) {
+            val currentSensor = sensors.getJSONObject(sensorId)
+            if (currentSensor.optString("TaskEnabled", "false").equals("false")) {
+                continue
+            }
+
+            val type = currentSensor.optString("Type")
+            if (type.startsWith("Environment")) {
+                parseEnvironment(listItems, type, currentSensor)
+            } else if (type.startsWith("Switch")) {
+                parseSwitch(listItems, type, currentSensor)
+            }
+        }
+
+        //web interface
+        listItems += ListViewItem(
+            title = resources.getString(R.string.espeasy_web_configuration_title),
+            summary = resources.getString(R.string.espeasy_web_configuration_summary),
+            hidden = url,
+            icon = R.drawable.ic_nav_settings
+        )
+
+        return listItems
+    }
+
+    private fun parseEnvironment(listItems: ArrayList<ListViewItem>, type: String, currentSensor: JSONObject)  {
+        var taskIcons = intArrayOf()
+        when (type) {
+            "Environment - BMx280" -> {
+                taskIcons += R.drawable.ic_device_thermometer
+                taskIcons += R.drawable.ic_humidity
+                taskIcons += R.drawable.ic_info
+            }
+            "Environment - DHT11/12/22  SONOFF2301/7021" -> {
+                taskIcons += R.drawable.ic_device_thermometer
+                taskIcons += R.drawable.ic_humidity
+            }
+            "Environment - DS18b20" -> {
+                taskIcons += R.drawable.ic_device_thermometer
+            }
+        }
+
+        val taskName = currentSensor.getString("TaskName")
+        for (taskId in 0 until taskIcons.size) {
+            val currentTask = currentSensor.getJSONArray("TaskValues").getJSONObject(taskId)
+            val currentValue = currentTask.getString("Value")
+            if (!currentValue.equals("nan")) {
+                val suffix = when (taskIcons[taskId]) {
+                    R.drawable.ic_device_thermometer -> " °C"
+                    R.drawable.ic_humidity -> " %"
+                    R.drawable.ic_info -> " hPa"
+                    else -> ""
+                }
+                listItems += ListViewItem(
+                    title = currentValue + suffix,
+                    summary = taskName + ": " + currentTask.getString("Name"),
+                    icon = taskIcons[taskId]
+                )
+            }
+        }
+    }
+
+    private fun parseSwitch(listItems: ArrayList<ListViewItem>, type: String, currentSensor: JSONObject) {
+        when (type) {
+            "Switch input - Switch" -> {
+                val currentState = currentSensor.getJSONArray("TaskValues").getJSONObject(0).getInt("Value") > 0
+                var taskName =currentSensor.getString("TaskName")
+                var gpioId = ""
+                val gpioFinder = Regex("~GPIO~([0-9]+)$")
+                val matchResult = gpioFinder.find(taskName)
+                if (matchResult != null && matchResult.groupValues.size > 1) {
+                    gpioId = matchResult.groupValues[1]
+                    taskName = taskName.replace("~GPIO~" + gpioId, "")
+                }
+                listItems += ListViewItem(
+                    title = taskName,
+                    summary = resources.getString(
+                        if (currentState) R.string.shelly_switch_summary_on
+                        else R.string.shelly_switch_summary_off
+                    ),
+                    hidden = gpioId,
+                    state = currentState,
+                    icon = R.drawable.ic_do
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_gauge.xml
+++ b/app/src/main/res/drawable/ic_gauge.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M11.98,4a10,10 0,0 0,-8.658 14.969h17.355A10,10 0,0 0,12 4a10,10 0,0 0,-0.02 0z"
+      android:fillColor="#e2e4e7"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M10.59,15.41a2,2 0,0 0,2.83 0l5.66,-8.49 -8.49,5.66a2,2 0,0 0,0 2.83z"
+      android:fillColor="#45494d"/>
+  <path
+      android:pathData="M20.38,8.57l-1.23,1.85a8,8 0,0 1,-0.22 7.58H5.07A8,8 0,0 1,15.58 6.85l1.85,-1.23A10,10 0,0 0,3.35 19a2,2 0,0 0,1.72 1h13.85a2,2 0,0 0,1.74 -1,10 10,0 0,0 -0.27,-10.44z"
+      android:fillColor="#6f7a84"/>
+</vector>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -25,6 +25,10 @@
     <string name="err_missing_address">Geben Sie bitte eine Adresse ein</string>
     <string name="err_missing_address_summary">Eine Adresse ist wichtig, damit die App das Gerät erreichen kann</string>
 
+    <string name="espeasy_update_interval">%1$d s</string>
+    <string name="espeasy_web_configuration_summary">Geräte-Website öffnen</string>
+    <string name="espeasy_web_configuration_title">Einstellungen</string>
+
     <string name="hue_connect">Verbinde dich mit deiner Bridge</string>
     <string name="hue_press_button">Bitte drücke den Knopf auf deiner Bridge um fortzufahren.</string>
     <string name="hue_tap">Tippe um Auszuwählen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -25,7 +25,6 @@
     <string name="err_missing_address">Geben Sie bitte eine Adresse ein</string>
     <string name="err_missing_address_summary">Eine Adresse ist wichtig, damit die App das Gerät erreichen kann</string>
 
-    <string name="espeasy_update_interval">%1$d s</string>
     <string name="espeasy_web_configuration_summary">Geräte-Website öffnen</string>
     <string name="espeasy_web_configuration_title">Einstellungen</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,10 @@
     <string name="err_missing_address">Please enter an address</string>
     <string name="err_missing_address_summary">An address is important because it allows the app to reach the device</string>
 
+    <string name="espeasy_update_interval">%1$d s</string>
+    <string name="espeasy_web_configuration_summary">Open device website</string>
+    <string name="espeasy_web_configuration_title">Configuration</string>
+
     <string name="hue_connect">Connect to your Bridge</string>
     <string name="hue_press_button">Please press the button on your bridge to continue.</string>
     <string name="hue_tap">Tap to select</string>
@@ -160,6 +164,7 @@
     </string-array>
     <string-array name="pref_add_mode_array" translatable="false">
         <item>SimpleHome API</item>
+        <item>ESP Easy</item>
         <item>Fritz! Auto-Login</item>
         <item>Hue API</item>
         <item>Node-RED</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,7 +25,6 @@
     <string name="err_missing_address">Please enter an address</string>
     <string name="err_missing_address_summary">An address is important because it allows the app to reach the device</string>
 
-    <string name="espeasy_update_interval">%1$d s</string>
     <string name="espeasy_web_configuration_summary">Open device website</string>
     <string name="espeasy_web_configuration_title">Configuration</string>
 

--- a/app/src/test/java/io/github/domi04151309/home/helpers/EspEasyAPIParserTest.kt
+++ b/app/src/test/java/io/github/domi04151309/home/helpers/EspEasyAPIParserTest.kt
@@ -1,0 +1,131 @@
+package io.github.domi04151309.home.helpers
+
+import android.content.res.Resources
+import io.github.domi04151309.home.R
+import org.junit.Assert
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class EspEasyAPIParserTest {
+    private var resources: Resources = RuntimeEnvironment.getApplication().applicationContext.resources
+
+    @Test
+    fun parseInfo1() {
+        val infoJson = JSONObject(javaClass.getResource("/espeasy/espeasy-1.json").readText())
+
+        val eeap = EspEasyAPIParser("http://espeasy/", resources)
+        val listItems = eeap.parseInfo(infoJson)
+        Assert.assertEquals(5, listItems.size)
+
+        //sensor 1: Temperature + Humidity
+        var num = 0
+        Assert.assertEquals("24.7 °C", listItems[num].title)
+        Assert.assertEquals("DHT: Temperatur", listItems[num].summary)
+        Assert.assertEquals(null, listItems[num].state)
+        Assert.assertEquals("", listItems[num].hidden)
+        Assert.assertEquals(R.drawable.ic_device_thermometer, listItems[num].icon)
+
+        num++
+        Assert.assertEquals("39.5 %", listItems[num].title)
+        Assert.assertEquals("DHT: Feuchte", listItems[num].summary)
+        Assert.assertEquals(null, listItems[num].state)
+        Assert.assertEquals("", listItems[num].hidden)
+        Assert.assertEquals(R.drawable.ic_humidity, listItems[num].icon)
+
+        //sensor 2: Temperature only
+        num++
+        Assert.assertEquals("0 °C", listItems[num].title)
+        Assert.assertEquals("DS: Temperatur", listItems[num].summary)
+        Assert.assertEquals(null, listItems[num].state)
+        Assert.assertEquals("", listItems[num].hidden)
+        Assert.assertEquals(R.drawable.ic_device_thermometer, listItems[num].icon)
+
+        //sensor 3: Switch in off mode
+        num++
+        Assert.assertEquals("Relais", listItems[num].title)
+        Assert.assertEquals(resources.getString(R.string.shelly_switch_summary_off), listItems[num].summary)
+        Assert.assertEquals(false, listItems[num].state)
+        Assert.assertEquals("12", listItems[num].hidden)
+        Assert.assertEquals(R.drawable.ic_do, listItems[num].icon)
+
+        //web interface
+        num++
+        Assert.assertEquals(resources.getString(R.string.espeasy_web_configuration_title), listItems[num].title)
+        Assert.assertEquals(resources.getString(R.string.espeasy_web_configuration_summary), listItems[num].summary)
+        Assert.assertEquals(null, listItems[num].state)
+        Assert.assertEquals("http://espeasy/", listItems[num].hidden)
+        Assert.assertEquals(R.drawable.ic_nav_settings, listItems[num].icon)
+    }
+
+    @Test
+    fun parseInfoDisabledTasks() {
+        val infoJson = JSONObject(javaClass.getResource("/espeasy/espeasy-disabledtasks.json").readText())
+
+        val eeap = EspEasyAPIParser("http://espeasy/", resources)
+        val listItems = eeap.parseInfo(infoJson)
+
+        Assert.assertEquals(1, listItems.size)
+        //only the web interface
+        val num = 0
+        Assert.assertEquals("http://espeasy/", listItems[num].hidden)
+    }
+
+    @Test
+    fun parseInfoHideNanSensorValues() {
+        val infoJson = JSONObject(javaClass.getResource("/espeasy/espeasy-nan.json").readText())
+
+        val eeap = EspEasyAPIParser("http://espeasy/", resources)
+        val listItems = eeap.parseInfo(infoJson)
+
+        Assert.assertEquals(2, listItems.size)
+
+        //first sensor value is humidity since temperature returns a "NaN" that we hidd
+        var num = 0
+        Assert.assertEquals("39.5 %", listItems[num].title)
+        Assert.assertEquals("DHT: Feuchte", listItems[num].summary)
+        Assert.assertEquals(null, listItems[num].state)
+        Assert.assertEquals("", listItems[num].hidden)
+        Assert.assertEquals(R.drawable.ic_humidity, listItems[num].icon)
+
+        num++
+        Assert.assertEquals("http://espeasy/", listItems[num].hidden)
+    }
+
+    @Test
+    fun parseInfoPressure() {
+        val infoJson = JSONObject(javaClass.getResource("/espeasy/espeasy-pressure.json").readText())
+
+        val eeap = EspEasyAPIParser("http://espeasy/", resources)
+        val listItems = eeap.parseInfo(infoJson)
+
+        Assert.assertEquals(4, listItems.size)
+        //sensor 1: Temperature + Humidity + Pressure
+        var num = 0
+        Assert.assertEquals("30 °C", listItems[num].title)
+        Assert.assertEquals("BMP_HWR: Temp_BMP", listItems[num].summary)
+        Assert.assertEquals(null, listItems[num].state)
+        Assert.assertEquals("", listItems[num].hidden)
+        Assert.assertEquals(R.drawable.ic_device_thermometer, listItems[num].icon)
+
+        num++
+        Assert.assertEquals("0 %", listItems[num].title)
+        Assert.assertEquals("BMP_HWR: Feuchte_BMP", listItems[num].summary)
+        Assert.assertEquals(null, listItems[num].state)
+        Assert.assertEquals("", listItems[num].hidden)
+        Assert.assertEquals(R.drawable.ic_humidity, listItems[num].icon)
+
+        num++
+        Assert.assertEquals("1004 hPa", listItems[num].title)
+        Assert.assertEquals("BMP_HWR: Druck_BMP", listItems[num].summary)
+        Assert.assertEquals(null, listItems[num].state)
+        Assert.assertEquals("", listItems[num].hidden)
+        Assert.assertEquals(R.drawable.ic_info, listItems[num].icon)
+
+        num++
+        Assert.assertEquals("http://espeasy/", listItems[num].hidden)
+    }
+}

--- a/app/src/test/resources/espeasy/espeasy-1.json
+++ b/app/src/test/resources/espeasy/espeasy-1.json
@@ -1,0 +1,196 @@
+{
+  "System": {
+    "Load": 100,
+    "Load LC": 3,
+    "Build": 20116,
+    "Git Build": "mega-20211105_c79d675",
+    "System Libraries": "ESP82xx Core 2843a5ac, NONOS SDK 2.2.2-dev(38a443e), LWIP: 2.1.2 PUYA support",
+    "Plugin Count": 47,
+    "Plugin Description": "[Normal]",
+    "Local Time": "2021-12-10 20:10:10",
+    "Time Source": "NTP",
+    "Time Wander": 0,
+    "Use NTP": "true",
+    "Unit Number": 0,
+    "Unit Name": "ESP_Easy",
+    "Uptime": 3,
+    "Uptime (ms)": 157461,
+    "Last Boot Cause": "Cold Boot",
+    "Reset Reason": "External System",
+    "CPU Eco Mode": "false",
+    "Heap Max Free Block": 9928,
+    "Heap Fragmentation": 14,
+    "Free RAM": 11600,
+    "Free Stack": 3488,
+    "Sunrise": "5:50",
+    "Sunset": "17:57",
+    "Timezone Offset": 1,
+    "Latitude": 0,
+    "Longitude": 0
+  },
+  "WiFi": {
+    "Hostname": "ESP-Easy",
+    "IP Config": "DHCP",
+    "IP Address": "192.168.3.119",
+    "IP Subnet": "255.255.255.0",
+    "Gateway": "192.168.3.91",
+    "STA MAC": "60:01:94:01:6E:75",
+    "DNS 1": "192.168.3.3",
+    "DNS 2": "(IP unset)",
+    "SSID": "home.cweiske.de",
+    "BSSID": "5C:49:79:3B:B1:E0",
+    "Channel": 1,
+    "Encryption Type": "WPA2/PSK",
+    "Connected msec": 153000,
+    "Last Disconnect Reason": 1,
+    "Last Disconnect Reason str": "(1) Unspecified",
+    "Number Reconnects": 0,
+    "Configured SSID1": "home.cweiske.de",
+    "Configured SSID2": "Neo809B",
+    "Force WiFi B/G": "false",
+    "Restart WiFi Lost Conn": "false",
+    "Force WiFi No Sleep": "false",
+    "Periodical send Gratuitous ARP": "true",
+    "Connection Failure Threshold": 0,
+    "Max WiFi TX Power": 17.5,
+    "Current WiFi TX Power": 14,
+    "WiFi Sensitivity Margin": 3,
+    "Send With Max TX Power": "false",
+    "Extra WiFi scan loops": 0,
+    "Use Last Connected AP from RTC": "false",
+    "RSSI": -79
+  },
+  "Sensors": [
+    {
+      "TaskValues": [
+        {
+          "ValueNumber": 1,
+          "Name": "Temperatur",
+          "NrDecimals": 1,
+          "Value": 24.7
+        },
+        {
+          "ValueNumber": 2,
+          "Name": "Feuchte",
+          "NrDecimals": 1,
+          "Value": 39.5
+        }
+      ],
+      "DataAcquisition": [
+        {
+          "Controller": 1,
+          "IDX": 0,
+          "Enabled": "true"
+        },
+        {
+          "Controller": 2,
+          "IDX": 0,
+          "Enabled": "true"
+        },
+        {
+          "Controller": 3,
+          "IDX": 0,
+          "Enabled": "false"
+        }
+      ],
+      "TaskInterval": 5,
+      "Type": "Environment - DHT11/12/22  SONOFF2301/7021",
+      "TaskName": "DHT",
+      "TaskDeviceNumber": 5,
+      "TaskEnabled": "true",
+      "TaskNumber": 1
+    },
+    {
+      "TaskValues": [
+        {
+          "ValueNumber": 1,
+          "Name": "Temperatur",
+          "NrDecimals": 1,
+          "Value": 0
+        }
+      ],
+      "DataAcquisition": [
+        {
+          "Controller": 1,
+          "IDX": 0,
+          "Enabled": "true"
+        },
+        {
+          "Controller": 2,
+          "IDX": 0,
+          "Enabled": "true"
+        },
+        {
+          "Controller": 3,
+          "IDX": 0,
+          "Enabled": "false"
+        }
+      ],
+      "TaskInterval": 60,
+      "Type": "Environment - DS18b20",
+      "TaskName": "DS",
+      "TaskDeviceNumber": 4,
+      "TaskEnabled": "true",
+      "TaskNumber": 2
+    },
+    {
+      "TaskValues": [
+        {
+          "ValueNumber": 1,
+          "Name": "State",
+          "NrDecimals": 0,
+          "Value": 0
+        }
+      ],
+      "DataAcquisition": [
+        {
+          "Controller": 1,
+          "IDX": 0,
+          "Enabled": "false"
+        },
+        {
+          "Controller": 2,
+          "IDX": 0,
+          "Enabled": "false"
+        },
+        {
+          "Controller": 3,
+          "IDX": 0,
+          "Enabled": "false"
+        }
+      ],
+      "TaskInterval": 0,
+      "Type": "Switch input - Switch",
+      "TaskName": "Relais~GPIO~12",
+      "TaskDeviceNumber": 1,
+      "TaskEnabled": "true",
+      "TaskNumber": 3
+    },
+    {
+      "DataAcquisition": [
+        {
+          "Controller": 1,
+          "IDX": 0,
+          "Enabled": "false"
+        },
+        {
+          "Controller": 2,
+          "IDX": 0,
+          "Enabled": "false"
+        },
+        {
+          "Controller": 3,
+          "IDX": 0,
+          "Enabled": "false"
+        }
+      ],
+      "TaskInterval": 1,
+      "Type": "Display - OLED SSD1306",
+      "TaskName": "OLED",
+      "TaskDeviceNumber": 23,
+      "TaskEnabled": "true",
+      "TaskNumber": 4
+    }
+  ],
+  "TTL": 5000
+}

--- a/app/src/test/resources/espeasy/espeasy-disabledtasks.json
+++ b/app/src/test/resources/espeasy/espeasy-disabledtasks.json
@@ -1,0 +1,161 @@
+{
+  "System": {
+    "Build": 20111,
+    "Git Build": "",
+    "System Libraries": "ESP82xx Core 2843a5ac, NONOS SDK 2.2.2-dev(38a443e), LWIP: 2.1.2 PUYA support",
+    "Plugin Count": 46,
+    "Plugin Description": "[Normal]",
+    "Local Time": "2021-12-10 22:54:36",
+    "Unit Number": 242,
+    "Unit Name": "TH2",
+    "Uptime": 62,
+    "Last Boot Cause": "Manual reboot",
+    "Reset Reason": "Software/System restart",
+    "Load": 5.24,
+    "Load LC": 3473,
+    "CPU Eco Mode": "false",
+    "Heap Max Free Block": 20512,
+    "Heap Fragmentation": 10,
+    "Free RAM": 22760
+  },
+  "WiFi": {
+    "Hostname": "TH2-242",
+    "IP Config": "DHCP",
+    "IP Address": "192.168.3.113",
+    "IP Subnet": "255.255.255.0",
+    "Gateway": "192.168.3.91",
+    "STA MAC": "CC:50:E3:4F:FD:A2",
+    "DNS 1": "192.168.3.3",
+    "DNS 2": "(IP unset)",
+    "SSID": "home.cweiske.de",
+    "BSSID": "5C:49:79:3B:B1:E0",
+    "Channel": 1,
+    "Connected msec": 3713000,
+    "Last Disconnect Reason": 1,
+    "Last Disconnect Reason str": "(1) Unspecified",
+    "Number Reconnects": 0,
+    "Force WiFi B/G": "false",
+    "Restart WiFi Lost Conn": "false",
+    "Force WiFi No Sleep": "false",
+    "Connection Failure Threshold": 0,
+    "RSSI": -72
+  },
+  "nodes": [
+    {
+      "nr": 242,
+      "name": "TH2",
+      "build": 20111,
+      "platform": "ESP Easy Mega",
+      "ip": "192.168.3.113",
+      "age": 1
+    }
+  ],
+  "Sensors": [
+    {
+      "TaskValues": [
+        {
+          "ValueNumber": 1,
+          "Name": "Ausgang",
+          "NrDecimals": 0,
+          "Value": 0
+        }
+      ],
+      "DataAcquisition": [
+        {
+          "Controller": 1,
+          "IDX": 0,
+          "Enabled": "true"
+        },
+        {
+          "Controller": 2,
+          "IDX": 0,
+          "Enabled": "false"
+        },
+        {
+          "Controller": 3,
+          "IDX": 0,
+          "Enabled": "false"
+        }
+      ],
+      "TaskInterval": 0,
+      "Type": "Switch input - Switch",
+      "TaskName": "Relais",
+      "TaskDeviceNumber": 1,
+      "TaskEnabled": "false",
+      "TaskNumber": 1
+    },
+    {
+      "TaskValues": [
+        {
+          "ValueNumber": 1,
+          "Name": "Eingang",
+          "NrDecimals": 0,
+          "Value": 0
+        }
+      ],
+      "DataAcquisition": [
+        {
+          "Controller": 1,
+          "IDX": 0,
+          "Enabled": "true"
+        },
+        {
+          "Controller": 2,
+          "IDX": 0,
+          "Enabled": "false"
+        },
+        {
+          "Controller": 3,
+          "IDX": 0,
+          "Enabled": "false"
+        }
+      ],
+      "TaskInterval": 0,
+      "Type": "Switch input - Switch",
+      "TaskName": "Schalter",
+      "TaskDeviceNumber": 1,
+      "TaskEnabled": "false",
+      "TaskNumber": 2
+    },
+    {
+      "TaskValues": [
+        {
+          "ValueNumber": 1,
+          "Name": "Temperatur",
+          "NrDecimals": 2,
+          "Value": "nan"
+        },
+        {
+          "ValueNumber": 2,
+          "Name": "Feuchte",
+          "NrDecimals": 2,
+          "Value": "nan"
+        }
+      ],
+      "DataAcquisition": [
+        {
+          "Controller": 1,
+          "IDX": 0,
+          "Enabled": "true"
+        },
+        {
+          "Controller": 2,
+          "IDX": 0,
+          "Enabled": "false"
+        },
+        {
+          "Controller": 3,
+          "IDX": 0,
+          "Enabled": "false"
+        }
+      ],
+      "TaskInterval": 300,
+      "Type": "Environment - DHT11/12/22  SONOFF2301/7021",
+      "TaskName": "DHT_TH2",
+      "TaskDeviceNumber": 5,
+      "TaskEnabled": "false",
+      "TaskNumber": 3
+    }
+  ],
+  "TTL": 60000
+}

--- a/app/src/test/resources/espeasy/espeasy-nan.json
+++ b/app/src/test/resources/espeasy/espeasy-nan.json
@@ -1,0 +1,105 @@
+{
+  "System": {
+    "Load": 100,
+    "Load LC": 3,
+    "Build": 20116,
+    "Git Build": "mega-20211105_c79d675",
+    "System Libraries": "ESP82xx Core 2843a5ac, NONOS SDK 2.2.2-dev(38a443e), LWIP: 2.1.2 PUYA support",
+    "Plugin Count": 47,
+    "Plugin Description": "[Normal]",
+    "Local Time": "2021-12-10 20:10:10",
+    "Time Source": "NTP",
+    "Time Wander": 0,
+    "Use NTP": "true",
+    "Unit Number": 0,
+    "Unit Name": "ESP_Easy",
+    "Uptime": 3,
+    "Uptime (ms)": 157461,
+    "Last Boot Cause": "Cold Boot",
+    "Reset Reason": "External System",
+    "CPU Eco Mode": "false",
+    "Heap Max Free Block": 9928,
+    "Heap Fragmentation": 14,
+    "Free RAM": 11600,
+    "Free Stack": 3488,
+    "Sunrise": "5:50",
+    "Sunset": "17:57",
+    "Timezone Offset": 1,
+    "Latitude": 0,
+    "Longitude": 0
+  },
+  "WiFi": {
+    "Hostname": "ESP-Easy",
+    "IP Config": "DHCP",
+    "IP Address": "192.168.3.119",
+    "IP Subnet": "255.255.255.0",
+    "Gateway": "192.168.3.91",
+    "STA MAC": "60:01:94:01:6E:75",
+    "DNS 1": "192.168.3.3",
+    "DNS 2": "(IP unset)",
+    "SSID": "home.cweiske.de",
+    "BSSID": "5C:49:79:3B:B1:E0",
+    "Channel": 1,
+    "Encryption Type": "WPA2/PSK",
+    "Connected msec": 153000,
+    "Last Disconnect Reason": 1,
+    "Last Disconnect Reason str": "(1) Unspecified",
+    "Number Reconnects": 0,
+    "Configured SSID1": "home.cweiske.de",
+    "Configured SSID2": "Neo809B",
+    "Force WiFi B/G": "false",
+    "Restart WiFi Lost Conn": "false",
+    "Force WiFi No Sleep": "false",
+    "Periodical send Gratuitous ARP": "true",
+    "Connection Failure Threshold": 0,
+    "Max WiFi TX Power": 17.5,
+    "Current WiFi TX Power": 14,
+    "WiFi Sensitivity Margin": 3,
+    "Send With Max TX Power": "false",
+    "Extra WiFi scan loops": 0,
+    "Use Last Connected AP from RTC": "false",
+    "RSSI": -79
+  },
+  "Sensors": [
+    {
+      "TaskValues": [
+        {
+          "ValueNumber": 1,
+          "Name": "Temperatur",
+          "NrDecimals": 1,
+          "Value": "nan"
+        },
+        {
+          "ValueNumber": 2,
+          "Name": "Feuchte",
+          "NrDecimals": 1,
+          "Value": 39.5
+        }
+      ],
+      "DataAcquisition": [
+        {
+          "Controller": 1,
+          "IDX": 0,
+          "Enabled": "true"
+        },
+        {
+          "Controller": 2,
+          "IDX": 0,
+          "Enabled": "true"
+        },
+        {
+          "Controller": 3,
+          "IDX": 0,
+          "Enabled": "false"
+        }
+      ],
+      "TaskInterval": 5,
+      "Type": "Environment - DHT11/12/22  SONOFF2301/7021",
+      "TaskName": "DHT",
+      "TaskDeviceNumber": 5,
+      "TaskEnabled": "true",
+      "TaskNumber": 1
+    }
+  ],
+  "TTL": 5000
+}

--- a/app/src/test/resources/espeasy/espeasy-pressure.json
+++ b/app/src/test/resources/espeasy/espeasy-pressure.json
@@ -1,0 +1,110 @@
+{
+  "System": {
+    "Build": 20111,
+    "Git Build": "",
+    "System Libraries": "ESP82xx Core 2843a5ac, NONOS SDK 2.2.2-dev(38a443e), LWIP: 2.1.2 PUYA support",
+    "Plugin Count": 46,
+    "Plugin Description": "[Normal]",
+    "Local Time": "2021-12-10 22:54:32",
+    "Unit Number": 244,
+    "Unit Name": "HWR",
+    "Uptime": 121667,
+    "Last Boot Cause": "Manual reboot",
+    "Reset Reason": "Exception",
+    "Load": 14.59,
+    "Load LC": 2255,
+    "CPU Eco Mode": "false",
+    "Heap Max Free Block": 14560,
+    "Heap Fragmentation": 8,
+    "Free RAM": 15696
+  },
+  "WiFi": {
+    "Hostname": "HWR",
+    "IP Config": "DHCP",
+    "IP Address": "172.22.1.244",
+    "IP Subnet": "255.255.255.0",
+    "Gateway": "172.22.1.1",
+    "STA MAC": "5C:CF:7F:2A:1C:D6",
+    "DNS 1": "172.22.1.20",
+    "DNS 2": "(IP unset)",
+    "SSID": "EndeDerVernunft",
+    "BSSID": "E8:DF:70:E4:A7:9C",
+    "Channel": 11,
+    "Connected msec": 1779758000,
+    "Last Disconnect Reason": 8,
+    "Last Disconnect Reason str": "(8) Assoc leave",
+    "Number Reconnects": 2,
+    "Force WiFi B/G": "false",
+    "Restart WiFi Lost Conn": "false",
+    "Force WiFi No Sleep": "false",
+    "Periodical send Gratuitous ARP": "true",
+    "Connection Failure Threshold": 0,
+    "RSSI": -80
+  },
+  "nodes": [
+    {
+      "nr": 244,
+      "name": "HWR",
+      "build": 20111,
+      "platform": "ESP Easy Mega",
+      "ip": "172.22.1.244",
+      "age": 1
+    },
+    {
+      "nr": 245,
+      "name": "Saunahuette",
+      "build": 20116,
+      "platform": "ESP Easy Mega",
+      "ip": "172.22.1.245",
+      "age": 1
+    }
+  ],
+  "Sensors": [
+    {
+      "TaskValues": [
+        {
+          "ValueNumber": 1,
+          "Name": "Temp_BMP",
+          "NrDecimals": 0,
+          "Value": 30
+        },
+        {
+          "ValueNumber": 2,
+          "Name": "Feuchte_BMP",
+          "NrDecimals": 1,
+          "Value": 0
+        },
+        {
+          "ValueNumber": 3,
+          "Name": "Druck_BMP",
+          "NrDecimals": 0,
+          "Value": 1004
+        }
+      ],
+      "DataAcquisition": [
+        {
+          "Controller": 1,
+          "IDX": 0,
+          "Enabled": "true"
+        },
+        {
+          "Controller": 2,
+          "IDX": 0,
+          "Enabled": "false"
+        },
+        {
+          "Controller": 3,
+          "IDX": 0,
+          "Enabled": "false"
+        }
+      ],
+      "TaskInterval": 60,
+      "Type": "Environment - BMx280",
+      "TaskName": "BMP_HWR",
+      "TaskDeviceNumber": 28,
+      "TaskEnabled": "true",
+      "TaskNumber": 1
+    }
+  ],
+  "TTL": 50000
+}


### PR DESCRIPTION
Sensor values for temperature, humidity and air pressure are shown.
Supported sensors:
- "Environment - BMx280"
- "Environment - DHT11/12/22  SONOFF2301/7021"
- "Environment - DS18b20"

Relays: Current state (on/off) is shown and you can switch them
if their name ends with `~GPIO~23`.
(We do not get the GPIO number from JSON, but need it for switching)
Supported switches:
- "Switch input - Switch"

Project information:
- https://www.letscontrolit.com/
- https://github.com/letscontrolit
- https://espeasy.readthedocs.io/en/latest/

Co-author: @znbrain


An air pressure icon is missing; I used the "info" icon

# Screenshots
They were made before the units were added to the numbers.

![2021-12-11 espeasy many](https://user-images.githubusercontent.com/59036/145673935-7dd39f29-9e01-41b5-ae3d-46e59dcb5d3e.jpg)
![2021-12-11 espeasy sauna](https://user-images.githubusercontent.com/59036/145673936-31c31ee4-526d-4477-8845-30dcda49f88c.jpg)
.