### PR TITLE
Shelly & ESP Easy real time status

### DIFF
--- a/app/src/main/java/io/github/domi04151309/home/activities/MainActivity.kt
+++ b/app/src/main/java/io/github/domi04151309/home/activities/MainActivity.kt
@@ -101,9 +101,9 @@ class MainActivity : AppCompatActivity() {
         }
     }
     private val unifiedRealTimeStatesCallback = object : UnifiedAPI.RealTimeStatesCallback {
-        override fun onStatesLoaded(states: ArrayList<Boolean?>, offset: Int) {
+        override fun onStatesLoaded(states: ArrayList<Boolean?>, offset: Int, dynamicSummary: Boolean) {
             for (i in 0 until states.size) {
-                if (states[i] != null) adapter.updateSwitch(i + offset, states[i] ?: return)
+                if (states[i] != null) adapter.updateSwitch(i + offset, states[i] ?: return, dynamicSummary)
             }
         }
     }

--- a/app/src/main/java/io/github/domi04151309/home/adapters/MainListAdapter.kt
+++ b/app/src/main/java/io/github/domi04151309/home/adapters/MainListAdapter.kt
@@ -99,10 +99,17 @@ class MainListAdapter(private var attachedTo: RecyclerView) : RecyclerView.Adapt
         }
     }
 
-    fun updateSwitch(position: Int, state: Boolean) {
+    fun updateSwitch(position: Int, state: Boolean, dynamicSummary: Boolean) {
         if (items[position].state != state) {
             items[position].state = state
-            (attachedTo.findViewHolderForAdapterPosition(position) as ViewHolder).stateSwitch.isChecked = state
+            val viewHolder = attachedTo.findViewHolderForAdapterPosition(position) as ViewHolder
+            viewHolder.stateSwitch.isChecked = state
+            if (dynamicSummary) {
+                viewHolder.summary.text = attachedTo.context.resources.getString(
+                    if (state) R.string.switch_summary_on
+                    else R.string.switch_summary_off
+                )
+            }
         }
     }
 

--- a/app/src/main/java/io/github/domi04151309/home/api/EspEasyAPI.kt
+++ b/app/src/main/java/io/github/domi04151309/home/api/EspEasyAPI.kt
@@ -43,7 +43,8 @@ class EspEasyAPI(
             { infoResponse ->
                 callback.onStatesLoaded(
                     parser.parseStates(infoResponse),
-                    offset
+                    offset,
+                    dynamicSummaries
                 )
             }, { }
         )

--- a/app/src/main/java/io/github/domi04151309/home/api/EspEasyAPI.kt
+++ b/app/src/main/java/io/github/domi04151309/home/api/EspEasyAPI.kt
@@ -14,13 +14,15 @@ class EspEasyAPI(
     recyclerViewInterface: HomeRecyclerViewHelperInterface?
 ) : UnifiedAPI(c, deviceId, recyclerViewInterface) {
 
+    private val parser = EspEasyAPIParser(c.resources)
+
     override fun loadList(callback: CallbackInterface) {
         val jsonObjectRequest = JsonObjectRequest(
             Request.Method.GET, url + "json", null,
             { infoResponse ->
                 callback.onItemsLoaded(
                     UnifiedRequestCallback(
-                        EspEasyAPIParser(c.resources).parseResponse(infoResponse),
+                        parser.parseResponse(infoResponse),
                         deviceId
                     ),
                     recyclerViewInterface
@@ -31,6 +33,19 @@ class EspEasyAPI(
                     Global.volleyError(c, error)
                 ), null)
             }
+        )
+        queue.add(jsonObjectRequest)
+    }
+
+    override fun loadStates(callback: RealTimeStatesCallback, offset: Int) {
+        val jsonObjectRequest = JsonObjectRequest(
+            Request.Method.GET, url + "json", null,
+            { infoResponse ->
+                callback.onStatesLoaded(
+                    parser.parseStates(infoResponse),
+                    offset
+                )
+            }, { }
         )
         queue.add(jsonObjectRequest)
     }

--- a/app/src/main/java/io/github/domi04151309/home/api/HueAPI.kt
+++ b/app/src/main/java/io/github/domi04151309/home/api/HueAPI.kt
@@ -105,7 +105,7 @@ class HueAPI(
                                 .getBoolean("any_on")
                         )
                     }
-                    callback.onStatesLoaded(states, offset)
+                    callback.onStatesLoaded(states, offset, dynamicSummaries)
                 } catch (e: Exception) {}
             },
             { }

--- a/app/src/main/java/io/github/domi04151309/home/api/ShellyAPI.kt
+++ b/app/src/main/java/io/github/domi04151309/home/api/ShellyAPI.kt
@@ -92,7 +92,8 @@ class ShellyAPI(
                         { statusResponse ->
                             callback.onStatesLoaded(
                                 parser.parseStates(settingsResponse, statusResponse),
-                                offset
+                                offset,
+                                dynamicSummaries
                             )
                         }, { }
                     ))
@@ -106,7 +107,8 @@ class ShellyAPI(
                         { statusResponse ->
                             callback.onStatesLoaded(
                                 parser.parseStates(configResponse, statusResponse),
-                                offset
+                                offset,
+                                dynamicSummaries
                             )
                         }, { }
                     ))

--- a/app/src/main/java/io/github/domi04151309/home/api/ShellyAPIParser.kt
+++ b/app/src/main/java/io/github/domi04151309/home/api/ShellyAPIParser.kt
@@ -58,29 +58,25 @@ class ShellyAPIParser(resources: Resources, private val version: Int): UnifiedAP
         }
 
         //external temperature sensors
-        val tempSensors = status.optJSONObject("ext_temperature")
-        if (tempSensors != null) {
-            for (sensorId in tempSensors.keys()) {
-                val currentSensor = tempSensors.getJSONObject(sensorId)
-                listItems += ListViewItem(
-                    title = "${currentSensor.getDouble("tC")} °C",
-                    summary = resources.getString(R.string.shelly_temperature_sensor_summary),
-                    icon = R.drawable.ic_device_thermometer
-                )
-            }
+        val tempSensors = status.optJSONObject("ext_temperature") ?: JSONObject()
+        for (sensorId in tempSensors.keys()) {
+            val currentSensor = tempSensors.getJSONObject(sensorId)
+            listItems += ListViewItem(
+                title = "${currentSensor.getDouble("tC")} °C",
+                summary = resources.getString(R.string.shelly_temperature_sensor_summary),
+                icon = R.drawable.ic_device_thermometer
+            )
         }
 
         //external humidity sensors
-        val humSensors = status.optJSONObject("ext_humidity")
-        if (humSensors != null) {
-            for (sensorId in humSensors.keys()) {
-                val currentSensor = humSensors.getJSONObject(sensorId)
-                listItems += ListViewItem(
-                    title = "${currentSensor.getDouble("hum")}%",
-                    summary = resources.getString(R.string.shelly_humidity_sensor_summary),
-                    icon = R.drawable.ic_device_hygrometer
-                )
-            }
+        val humSensors = status.optJSONObject("ext_humidity") ?: JSONObject()
+        for (sensorId in humSensors.keys()) {
+            val currentSensor = humSensors.getJSONObject(sensorId)
+            listItems += ListViewItem(
+                title = "${currentSensor.getDouble("hum")}%",
+                summary = resources.getString(R.string.shelly_humidity_sensor_summary),
+                icon = R.drawable.ic_device_hygrometer
+            )
         }
 
         return listItems
@@ -144,19 +140,15 @@ class ShellyAPIParser(resources: Resources, private val version: Int): UnifiedAP
         }
 
         //external temperature sensors
-        val tempSensors = status.optJSONObject("ext_temperature")
-        if (tempSensors != null) {
-            for (sensorId in tempSensors.keys()) {
-                listItems += null
-            }
+        val tempSensors = status.optJSONObject("ext_temperature") ?: JSONObject()
+        for (sensorId in tempSensors.keys()) {
+            listItems += null
         }
 
         //external humidity sensors
-        val humSensors = status.optJSONObject("ext_humidity")
-        if (humSensors != null) {
-            for (sensorId in humSensors.keys()) {
-                listItems += null
-            }
+        val humSensors = status.optJSONObject("ext_humidity") ?: JSONObject()
+        for (sensorId in humSensors.keys()) {
+            listItems += null
         }
 
         return listItems

--- a/app/src/main/java/io/github/domi04151309/home/api/ShellyAPIParser.kt
+++ b/app/src/main/java/io/github/domi04151309/home/api/ShellyAPIParser.kt
@@ -118,4 +118,58 @@ class ShellyAPIParser(resources: Resources, private val version: Int): UnifiedAP
 
         return listItems
     }
+
+    fun parseStates(config: JSONObject, status: JSONObject): ArrayList<Boolean?> {
+        return if (version == 1) parseStatesV1(config, status) else parseStatesV2(config, status)
+    }
+
+    private fun parseStatesV1(settings: JSONObject, status: JSONObject): ArrayList<Boolean?> {
+        val listItems = arrayListOf<Boolean?>()
+
+        //switches
+        val relays = settings.optJSONArray("relays") ?: JSONArray()
+        var currentRelay: JSONObject
+        var hideMeters = false
+        for (relayId in 0 until relays.length()) {
+            currentRelay = relays.getJSONObject(relayId)
+            listItems += currentRelay.getBoolean("ison")
+            //Shelly1 has the "user power constant" setting, but no actual meter
+            hideMeters = currentRelay.has("power")
+        }
+
+        //power meters
+        val meters = if (hideMeters) JSONArray() else status.optJSONArray("meters") ?: JSONArray()
+        for (meterId in 0 until meters.length()) {
+            listItems += null
+        }
+
+        //external temperature sensors
+        val tempSensors = status.optJSONObject("ext_temperature")
+        if (tempSensors != null) {
+            for (sensorId in tempSensors.keys()) {
+                listItems += null
+            }
+        }
+
+        //external humidity sensors
+        val humSensors = status.optJSONObject("ext_humidity")
+        if (humSensors != null) {
+            for (sensorId in humSensors.keys()) {
+                listItems += null
+            }
+        }
+
+        return listItems
+    }
+
+    private fun parseStatesV2(config: JSONObject, status: JSONObject): ArrayList<Boolean?> {
+        val listItems = arrayListOf<Boolean?>()
+
+        for (switchKey in config.keys()) {
+            if (!switchKey.startsWith("switch:")) continue
+            listItems += status.getJSONObject(switchKey).getBoolean("output")
+        }
+
+        return listItems
+    }
 }

--- a/app/src/main/java/io/github/domi04151309/home/api/UnifiedAPI.kt
+++ b/app/src/main/java/io/github/domi04151309/home/api/UnifiedAPI.kt
@@ -37,5 +37,6 @@ open class UnifiedAPI(
 
     open class Parser(protected val resources: Resources) {
         open fun parseResponse(response: JSONObject): ArrayList<ListViewItem> = arrayListOf()
+        open fun parseStates(response: JSONObject): ArrayList<Boolean?> = arrayListOf()
     }
 }

--- a/app/src/main/java/io/github/domi04151309/home/api/UnifiedAPI.kt
+++ b/app/src/main/java/io/github/domi04151309/home/api/UnifiedAPI.kt
@@ -22,7 +22,7 @@ open class UnifiedAPI(
     }
 
     interface RealTimeStatesCallback {
-        fun onStatesLoaded(states: ArrayList<Boolean?>, offset: Int)
+        fun onStatesLoaded(states: ArrayList<Boolean?>, offset: Int, dynamicSummary: Boolean)
     }
 
     var dynamicSummaries: Boolean = true

--- a/app/src/test/java/io/github/domi04151309/home/EspEasyAPIParserTest.kt
+++ b/app/src/test/java/io/github/domi04151309/home/EspEasyAPIParserTest.kt
@@ -54,12 +54,27 @@ class EspEasyAPIParserTest {
     }
 
     @Test
+    fun parseStates1() {
+        val infoJson = JSONObject(Helpers.getFileContents("/espeasy/espeasy-1.json"))
+
+        val states = parser.parseStates(infoJson)
+        Assert.assertEquals(arrayListOf(null, null, null, false), states)
+    }
+
+    @Test
     fun parseInfoDisabledTasks() {
         val infoJson = JSONObject(Helpers.getFileContents("/espeasy/espeasy-disabledtasks.json"))
 
         val listItems = parser.parseResponse(infoJson)
-
         Assert.assertEquals(0, listItems.size)
+    }
+
+    @Test
+    fun parseStatesDisabledTasks() {
+        val infoJson = JSONObject(Helpers.getFileContents("/espeasy/espeasy-disabledtasks.json"))
+
+        val states = parser.parseStates(infoJson)
+        Assert.assertEquals(arrayListOf<Boolean?>(), states)
     }
 
     @Test
@@ -77,6 +92,14 @@ class EspEasyAPIParserTest {
         Assert.assertEquals(null, listItems[num].state)
         Assert.assertEquals("", listItems[num].hidden)
         Assert.assertEquals(R.drawable.ic_device_hygrometer, listItems[num].icon)
+    }
+
+    @Test
+    fun parseStatesHideNanSensorValues() {
+        val infoJson = JSONObject(Helpers.getFileContents("/espeasy/espeasy-nan.json"))
+
+        val states = parser.parseStates(infoJson)
+        Assert.assertEquals(arrayListOf(null), states)
     }
 
     @Test
@@ -107,5 +130,13 @@ class EspEasyAPIParserTest {
         Assert.assertEquals(null, listItems[num].state)
         Assert.assertEquals("", listItems[num].hidden)
         Assert.assertEquals(R.drawable.ic_device_gauge, listItems[num].icon)
+    }
+
+    @Test
+    fun parseStatesPressure() {
+        val infoJson = JSONObject(Helpers.getFileContents("/espeasy/espeasy-pressure.json"))
+
+        val states = parser.parseStates(infoJson)
+        Assert.assertEquals(arrayListOf(null, null, null), states)
     }
 }

--- a/app/src/test/java/io/github/domi04151309/home/ShellyAPIParserTest.kt
+++ b/app/src/test/java/io/github/domi04151309/home/ShellyAPIParserTest.kt
@@ -39,6 +39,15 @@ class ShellyAPIParserTest {
     }
 
     @Test
+    fun parseStatesJsonV1_shellyPlug1WithPowerMeter() {
+        val settingsJson = JSONObject(Helpers.getFileContents("/shelly/shellyplug1-settings.json"))
+        val statusJson = JSONObject(Helpers.getFileContents("/shelly/shellyplug1-status.json"))
+
+        val states = parserV1.parseStates(settingsJson, statusJson)
+        Assert.assertEquals(arrayListOf(true, null), states)
+    }
+
+    @Test
     fun parseListItemsJsonV1_shellyPlug1ApplianceTypesForIcons() {
         val settingsJson = JSONObject(Helpers.getFileContents("/shelly/shellyplug1-icons-settings.json"))
         val statusJson = JSONObject(Helpers.getFileContents("/shelly/shellyplug1-icons-status.json"))
@@ -102,6 +111,15 @@ class ShellyAPIParserTest {
     }
 
     @Test
+    fun parseStatesJsonV1_shelly1WithTemperatureNoRelayName() {
+        val settingsJson = JSONObject(Helpers.getFileContents("/shelly/shelly1-settings.json"))
+        val statusJson = JSONObject(Helpers.getFileContents("/shelly/shelly1-status.json"))
+
+        val states = parserV1.parseStates(settingsJson, statusJson)
+        Assert.assertEquals(arrayListOf(false, null, null), states)
+    }
+
+    @Test
     fun parseListItemsJsonV2_shellyPlus1() {
         val configJson = JSONObject(Helpers.getFileContents("/shelly/shelly-plus-1-Shelly.GetConfig.json"))
         val statusJson = JSONObject(Helpers.getFileContents("/shelly/shelly-plus-1-Shelly.GetStatus.json"))
@@ -115,5 +133,14 @@ class ShellyAPIParserTest {
         Assert.assertEquals(true, listItems[num].state)
         Assert.assertEquals("0", listItems[num].hidden)
         Assert.assertEquals(R.drawable.ic_device_lamp, listItems[num].icon)
+    }
+
+    @Test
+    fun parseStatesJsonV2_shellyPlus1() {
+        val configJson = JSONObject(Helpers.getFileContents("/shelly/shelly-plus-1-Shelly.GetConfig.json"))
+        val statusJson = JSONObject(Helpers.getFileContents("/shelly/shelly-plus-1-Shelly.GetStatus.json"))
+
+        val states = parserV2.parseStates(configJson, statusJson)
+        Assert.assertEquals(arrayListOf(true), states)
     }
 }


### PR DESCRIPTION
Adds the real-time status functionality from the Hue API to Shelly and ESP Easy devices.

This makes the app check for state changes every second so that you can switch states with another device and still have an accurate representation of the real states on your own device.

Can you perform simple testing on real devices? @cweiske 

- [x]  Switch state changes when updated from the web interface
- [x]  Scroll position stays the same
- [x] Dynamic summary updates
- [ ] Power meter values