### PR TITLE
Add support for Shelly PM Mini Gen3

### DIFF
--- a/app/src/main/java/io/github/domi04151309/home/activities/DeviceInfoActivity.kt
+++ b/app/src/main/java/io/github/domi04151309/home/activities/DeviceInfoActivity.kt
@@ -50,6 +50,7 @@ class DeviceInfoActivity : BaseActivity(), RecyclerViewHelperInterface {
         when (device.mode) {
             Global.HUE_API -> showHueInfo(device, queue, items, recyclerView)
             Global.SHELLY_GEN_2 -> showShelly2Info(device, queue, items, recyclerView)
+            Global.SHELLY_GEN_3 -> showShelly2Info(device, queue, items, recyclerView)
         }
     }
 

--- a/app/src/main/java/io/github/domi04151309/home/activities/EditDeviceActivity.kt
+++ b/app/src/main/java/io/github/domi04151309/home/activities/EditDeviceActivity.kt
@@ -199,7 +199,7 @@ class EditDeviceActivity : BaseActivity() {
 
     private fun onConfigButtonClicked() {
         when (modeSpinner.text.toString()) {
-            Global.ESP_EASY, Global.SHELLY_GEN_1, Global.SHELLY_GEN_2 -> {
+            Global.ESP_EASY, Global.SHELLY_GEN_1, Global.SHELLY_GEN_2, Global.SHELLY_GEN_3 -> {
                 startActivity(
                     Intent(this, WebActivity::class.java)
                         .putExtra("URI", addressBox.editText?.text.toString())
@@ -340,6 +340,7 @@ class EditDeviceActivity : BaseActivity() {
                 Global.HUE_API,
                 Global.SHELLY_GEN_1,
                 Global.SHELLY_GEN_2,
+                Global.SHELLY_GEN_3,
                 Global.SIMPLE_HOME_API,
                 Global.TASMOTA,
             )
@@ -350,11 +351,13 @@ class EditDeviceActivity : BaseActivity() {
                 Global.NODE_RED,
                 Global.SHELLY_GEN_1,
                 Global.SHELLY_GEN_2,
+                Global.SHELLY_GEN_3,
             )
         private val HAS_INFO =
             arrayOf(
                 Global.HUE_API,
                 Global.SHELLY_GEN_2,
+                Global.SHELLY_GEN_3,
             )
     }
 }

--- a/app/src/main/java/io/github/domi04151309/home/api/ShellyAPIParser.kt
+++ b/app/src/main/java/io/github/domi04151309/home/api/ShellyAPIParser.kt
@@ -127,11 +127,11 @@ class ShellyAPIParser(resources: Resources, private val version: Int) :
                     parseSwitchV2(
                         config.getJSONObject(switchKey),
                         status.getJSONObject(switchKey),
-                        config
-                    )
-                );
+                        config,
+                    ),
+                )
             } else if (switchKey.startsWith("pm1:")) {
-                listItems.addAll(parsePowermeter1V2(config.getJSONObject(switchKey), status.getJSONObject(switchKey)));
+                listItems.addAll(parsePowermeter1V2(config.getJSONObject(switchKey), status.getJSONObject(switchKey)))
             }
         }
         return listItems
@@ -150,7 +150,7 @@ class ShellyAPIParser(resources: Resources, private val version: Int) :
                 summary = resources.getString(R.string.shelly_powermeter_summary),
                 hidden = currentId.toString(),
                 state = null,
-                icon = R.drawable.ic_device_electricity
+                icon = R.drawable.ic_device_electricity,
             )
         listItems +=
             ListViewItem(
@@ -158,7 +158,7 @@ class ShellyAPIParser(resources: Resources, private val version: Int) :
                 summary = resources.getString(R.string.shelly_powermeter_current),
                 hidden = currentId.toString() + "c",
                 state = null,
-                icon = 0
+                icon = 0,
             )
         listItems +=
             ListViewItem(
@@ -166,7 +166,7 @@ class ShellyAPIParser(resources: Resources, private val version: Int) :
                 summary = resources.getString(R.string.shelly_powermeter_voltage),
                 hidden = currentId.toString() + "v",
                 state = null,
-                icon = 0
+                icon = 0,
             )
 
         return listItems
@@ -175,7 +175,7 @@ class ShellyAPIParser(resources: Resources, private val version: Int) :
     private fun parseSwitchV2(
         switchConfig: JSONObject,
         switchStatus: JSONObject,
-        config: JSONObject
+        config: JSONObject,
     ): List<ListViewItem> {
         val listItems = mutableListOf<ListViewItem>()
         val currentId = switchConfig.getInt("id")
@@ -184,28 +184,28 @@ class ShellyAPIParser(resources: Resources, private val version: Int) :
         listItems +=
             ListViewItem(
                 title =
-                nameOrDefault(
-                    if (switchConfig.isNull("name")) "" else switchConfig.getString("name"),
-                    currentId,
-                ),
+                    nameOrDefault(
+                        if (switchConfig.isNull("name")) "" else switchConfig.getString("name"),
+                        currentId,
+                    ),
                 summary =
-                resources.getString(
-                    if (currentState) {
-                        R.string.switch_summary_on
-                    } else {
-                        R.string.switch_summary_off
-                    },
-                ),
+                    resources.getString(
+                        if (currentState) {
+                            R.string.switch_summary_on
+                        } else {
+                            R.string.switch_summary_off
+                        },
+                    ),
                 hidden = currentId.toString(),
                 state = currentState,
                 icon =
-                Global.getIcon(
-                    config.optJSONObject("sys")?.optJSONObject("ui_data")
-                        ?.optJSONArray("consumption_types")
-                        ?.getString(currentId)
-                        ?: "",
-                    R.drawable.ic_do,
-                ),
+                    Global.getIcon(
+                        config.optJSONObject("sys")?.optJSONObject("ui_data")
+                            ?.optJSONArray("consumption_types")
+                            ?.getString(currentId)
+                            ?: "",
+                        R.drawable.ic_do,
+                    ),
             )
         return listItems
     }

--- a/app/src/main/java/io/github/domi04151309/home/helpers/Global.kt
+++ b/app/src/main/java/io/github/domi04151309/home/helpers/Global.kt
@@ -30,6 +30,7 @@ internal object Global {
     const val HUE_API = "Hue API"
     const val SHELLY_GEN_1 = "Shelly Gen 1"
     const val SHELLY_GEN_2 = "Shelly Gen 2"
+    const val SHELLY_GEN_3 = "Shelly Gen 3"
     const val SIMPLE_HOME_API = "SimpleHome API"
     const val TASMOTA = "Tasmota"
     const val NODE_RED = "Node-RED"
@@ -41,6 +42,7 @@ internal object Global {
             HUE_API,
             SHELLY_GEN_1,
             SHELLY_GEN_2,
+            SHELLY_GEN_3,
             SIMPLE_HOME_API,
             TASMOTA,
         )
@@ -50,6 +52,7 @@ internal object Global {
             HUE_API,
             SHELLY_GEN_1,
             SHELLY_GEN_2,
+            SHELLY_GEN_3,
             SIMPLE_HOME_API,
             TASMOTA,
         )
@@ -68,6 +71,7 @@ internal object Global {
             TASMOTA -> Tasmota(context, deviceId, tasmotaHelperInterface ?: recyclerViewInterface)
             SHELLY_GEN_1 -> ShellyAPI(context, deviceId, recyclerViewInterface, 1)
             SHELLY_GEN_2 -> ShellyAPI(context, deviceId, recyclerViewInterface, 2)
+            SHELLY_GEN_3 -> ShellyAPI(context, deviceId, recyclerViewInterface, 2)
             else -> UnifiedAPI(context, deviceId, recyclerViewInterface)
         }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -59,6 +59,8 @@
 
     <string name="shelly_humidity_sensor_summary">Aktuelle Luftfeuchtigkeit</string>
     <string name="shelly_powermeter_summary">Aktueller Stromverbrauch</string>
+    <string name="shelly_powermeter_current">Stromstärke</string>
+    <string name="shelly_powermeter_voltage">Spannung</string>
     <string name="shelly_switch_title">Schalter %1$d</string>
     <string name="shelly_temperature_sensor_summary">Aktuelle Temperatur</string>
     <string name="shelly_wifi">W-Lan</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -62,6 +62,8 @@
 
     <string name="shelly_humidity_sensor_summary">Current humidity</string>
     <string name="shelly_powermeter_summary">Current power consumption</string>
+    <string name="shelly_powermeter_current">Current</string>
+    <string name="shelly_powermeter_voltage">Voltage</string>
     <string name="shelly_switch_title">Switch %1$d</string>
     <string name="shelly_temperature_sensor_summary">Current temperature</string>
     <string name="shelly_wifi">WiFi</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,6 +214,7 @@
         <item>Node-RED</item>
         <item>Shelly Gen 1</item>
         <item>Shelly Gen 2</item>
+        <item>Shelly Gen 3</item>
         <item>Tasmota</item>
         <item>Website</item>
     </string-array>

--- a/app/src/test/java/io/github/domi04151309/home/ShellyAPIParserTest.kt
+++ b/app/src/test/java/io/github/domi04151309/home/ShellyAPIParserTest.kt
@@ -154,4 +154,43 @@ class ShellyAPIParserTest {
         val states = parserV2.parseStates(configJson, statusJson)
         assertThat(states, `is`(listOf(true)))
     }
+
+    @Test
+    fun parseListItemsJsonV2_shellyMiniPMG3() {
+        val configJson = JSONObject(Helpers.getFileContents("/shelly/shelly-MiniPMG3-Shelly.GetConfig.json"))
+        val statusJson = JSONObject(Helpers.getFileContents("/shelly/shelly-MiniPMG3-Shelly.GetStatus.json"))
+
+        val listItems = parserV2.parseResponse(configJson, statusJson)
+        assertThat(listItems.size, `is`(3))
+
+        var num = 0
+        assertThat(listItems[num].title, `is`("4.0 W"))
+        assertThat(
+            listItems[num].summary,
+            `is`(resources.getString(R.string.shelly_powermeter_summary)),
+        )
+        assertThat(listItems[num].state, `is`(null as Boolean?))
+        assertThat(listItems[num].hidden, `is`("0"))
+        assertThat(listItems[num].icon, `is`(R.drawable.ic_device_electricity))
+
+        num = 1
+        assertThat(listItems[num].title, `is`("0.033 A"))
+        assertThat(
+            listItems[num].summary,
+            `is`(resources.getString(R.string.shelly_powermeter_current)),
+        )
+        assertThat(listItems[num].state, `is`(null as Boolean?))
+        assertThat(listItems[num].hidden, `is`("0c"))
+        assertThat(listItems[num].icon, `is`(0))
+
+        num = 2
+        assertThat(listItems[num].title, `is`("231.5 V"))
+        assertThat(
+            listItems[num].summary,
+            `is`(resources.getString(R.string.shelly_powermeter_voltage)),
+        )
+        assertThat(listItems[num].state, `is`(null as Boolean?))
+        assertThat(listItems[num].hidden, `is`("0v"))
+        assertThat(listItems[num].icon, `is`(0))
+    }
 }

--- a/app/src/test/resources/shelly/shelly-MiniPMG3-Shelly.GetConfig.json
+++ b/app/src/test/resources/shelly/shelly-MiniPMG3-Shelly.GetConfig.json
@@ -1,0 +1,109 @@
+{
+  "ble": {
+    "enable": false,
+    "rpc": {
+      "enable": false
+    },
+    "observer": {
+      "enable": false
+    }
+  },
+  "bthome": {},
+  "cloud": {
+    "enable": false,
+    "server": "iot.shelly.cloud:6012/jrpc"
+  },
+  "mqtt": {
+    "enable": false,
+    "server": null,
+    "client_id": "shellypmminig3-ecda3bc7176c",
+    "user": null,
+    "ssl_ca": null,
+    "topic_prefix": "shellypmminig3-ecda3bc7176c",
+    "rpc_ntf": true,
+    "status_ntf": false,
+    "use_client_cert": false,
+    "enable_rpc": true,
+    "enable_control": true
+  },
+  "pm1:0": {
+    "id": 0,
+    "name": "Kühlschrank",
+    "reverse": false
+  },
+  "sys": {
+    "device": {
+      "name": "shellypm4",
+      "mac": "ECDA3BC7176C",
+      "fw_id": "20241011-114503/1.4.4-g6d2a586",
+      "discoverable": true,
+      "eco_mode": false
+    },
+    "location": {
+      "tz": "Europe/Berlin",
+      "lat": 51.1591,
+      "lon": 12.2847
+    },
+    "debug": {
+      "level": 2,
+      "file_level": null,
+      "mqtt": {
+        "enable": false
+      },
+      "websocket": {
+        "enable": false
+      },
+      "udp": {
+        "addr": null
+      }
+    },
+    "ui_data": {},
+    "rpc_udp": {
+      "dst_addr": null,
+      "listen_port": null
+    },
+    "sntp": {
+      "server": "time.google.com"
+    },
+    "cfg_rev": 9
+  },
+  "wifi": {
+    "ap": {
+      "ssid": "ShellyPMMiniG3-ECDA3BC7176C",
+      "is_open": true,
+      "enable": false,
+      "range_extender": {
+        "enable": false
+      }
+    },
+    "sta": {
+      "ssid": "home.cweiske.de",
+      "is_open": false,
+      "enable": true,
+      "ipv4mode": "static",
+      "ip": "192.168.3.63",
+      "netmask": "255.255.255.0",
+      "gw": "192.168.3.3",
+      "nameserver": "192.168.3.3"
+    },
+    "sta1": {
+      "ssid": null,
+      "is_open": true,
+      "enable": false,
+      "ipv4mode": "dhcp",
+      "ip": null,
+      "netmask": null,
+      "gw": null,
+      "nameserver": null
+    },
+    "roam": {
+      "rssi_thr": -80,
+      "interval": 60
+    }
+  },
+  "ws": {
+    "enable": false,
+    "server": null,
+    "ssl_ca": "ca.pem"
+  }
+}

--- a/app/src/test/resources/shelly/shelly-MiniPMG3-Shelly.GetStatus.json
+++ b/app/src/test/resources/shelly/shelly-MiniPMG3-Shelly.GetStatus.json
@@ -1,0 +1,69 @@
+{
+  "ble": {},
+  "bthome": {
+    "errors": [
+      "bluetooth_disabled"
+    ]
+  },
+  "cloud": {
+    "connected": false
+  },
+  "mqtt": {
+    "connected": false
+  },
+  "pm1:0": {
+    "id": 0,
+    "voltage": 231.5,
+    "current": 0.033,
+    "apower": 4,
+    "freq": 50.1,
+    "aenergy": {
+      "total": 1.695,
+      "by_minute": [
+        0,
+        0,
+        211.882
+      ],
+      "minute_ts": 1738782780
+    },
+    "ret_aenergy": {
+      "total": 0,
+      "by_minute": [
+        0,
+        0,
+        0
+      ],
+      "minute_ts": 1738782780
+    }
+  },
+  "sys": {
+    "mac": "ECDA3BC7176C",
+    "restart_required": false,
+    "time": "20:13",
+    "unixtime": 1738782813,
+    "uptime": 1546,
+    "ram_size": 260924,
+    "ram_free": 143424,
+    "fs_size": 1048576,
+    "fs_free": 618496,
+    "cfg_rev": 9,
+    "kvs_rev": 5,
+    "schedule_rev": 0,
+    "webhook_rev": 0,
+    "available_updates": {
+      "beta": {
+        "version": "1.5.0-beta2"
+      }
+    },
+    "reset_reason": 3
+  },
+  "wifi": {
+    "sta_ip": "192.168.3.63",
+    "status": "got ip",
+    "ssid": "home.cweiske.de",
+    "rssi": -64
+  },
+  "ws": {
+    "connected": false
+  }
+}


### PR DESCRIPTION
Shows current power usage ("4.0 W"), current ("0.002 A") and voltage ("231.5 V").

I've added a new "Shelly Gen 3" device mode which uses the gen2 API, since they are identical.

Device discovery is kinda broken, because the Gen3 devices support IPv6. The IPv6 address added in the device list contains the network interface, which breaks the URL (`http://fe80::b4bc:5174:a413:c54f%wlan0` or so). This is not fixed.

https://www.shelly.com/products/shelly-pm-mini-gen3