### PR TITLE
New translations and language selection setting added

### DIFF
--- a/app/src/main/java/io/github/domi04151309/home/Application.kt
+++ b/app/src/main/java/io/github/domi04151309/home/Application.kt
@@ -1,8 +1,14 @@
 package io.github.domi04151309.home
 
+import android.content.Context
 import com.google.android.material.color.DynamicColors
+import io.github.domi04151309.home.helpers.LocaleHelper
 
 class Application : android.app.Application() {
+    override fun attachBaseContext(base: Context) {
+        super.attachBaseContext(LocaleHelper.wrapContext(base))
+    }
+
     override fun onCreate() {
         super.onCreate()
         DynamicColors.applyToActivitiesIfAvailable(this)

--- a/app/src/main/java/io/github/domi04151309/home/activities/BaseActivity.kt
+++ b/app/src/main/java/io/github/domi04151309/home/activities/BaseActivity.kt
@@ -1,5 +1,6 @@
 package io.github.domi04151309.home.activities
 
+import android.content.Context
 import android.content.res.Configuration
 import android.os.Bundle
 import android.view.View
@@ -8,9 +9,16 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import io.github.domi04151309.home.R
+import io.github.domi04151309.home.helpers.LocaleHelper
 
 abstract class BaseActivity : AppCompatActivity() {
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(LocaleHelper.wrapContext(newBase))
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Update configuration before creating the activity
+        LocaleHelper.updateActivityConfiguration(this)
         super.onCreate(savedInstanceState)
         if (resources.configuration.uiMode.and(
                 Configuration.UI_MODE_NIGHT_MASK,

--- a/app/src/main/java/io/github/domi04151309/home/activities/HueConnectActivity.kt
+++ b/app/src/main/java/io/github/domi04151309/home/activities/HueConnectActivity.kt
@@ -32,7 +32,9 @@ class HueConnectActivity : BaseActivity() {
         val jsonRequestObject = JSONObject("""{ "devicetype": "Home App#${android.os.Build.PRODUCT}" }""")
         requestToRegisterUser =
             CustomJsonArrayRequest(
-                Request.Method.POST, Devices(this).getDeviceById(deviceId).address + "api", jsonRequestObject,
+                Request.Method.POST,
+                Devices(this).getDeviceById(deviceId).address + "api",
+                jsonRequestObject,
                 { response ->
                     val responseObject = response.getJSONObject(0)
                     if (responseObject.has("success") && !success) {

--- a/app/src/main/java/io/github/domi04151309/home/activities/MainActivity.kt
+++ b/app/src/main/java/io/github/domi04151309/home/activities/MainActivity.kt
@@ -278,7 +278,9 @@ class MainActivity : BaseActivity() {
             startActivityAndReset(Intent(this, DevicesActivity::class.java))
         }
 
-        findViewById<MaterialToolbar>(R.id.toolbar).setOnMenuItemClickListener {
+        val toolbar = findViewById<MaterialToolbar>(R.id.toolbar)
+        toolbar.setTitle(R.string.app_name)
+        toolbar.setOnMenuItemClickListener {
             startActivity(
                 Intent(
                     this@MainActivity,

--- a/app/src/main/java/io/github/domi04151309/home/activities/SettingsActivity.kt
+++ b/app/src/main/java/io/github/domi04151309/home/activities/SettingsActivity.kt
@@ -14,6 +14,7 @@ import io.github.domi04151309.home.R
 import io.github.domi04151309.home.fragments.PreferenceFragment
 import io.github.domi04151309.home.helpers.Devices
 import io.github.domi04151309.home.helpers.Global
+import io.github.domi04151309.home.helpers.LocaleHelper
 import io.github.domi04151309.home.helpers.P
 
 class SettingsActivity : BaseActivity() {
@@ -80,6 +81,40 @@ class SettingsActivity : BaseActivity() {
                 )
                 true
             }
+            setupLanguagePreference()
+        }
+
+        private fun setupLanguagePreference() {
+            findPreference<Preference>(P.PREF_LANGUAGE)?.setOnPreferenceChangeListener { _, newValue ->
+                val newLang = newValue as String
+                LocaleHelper.setNewLocale(requireContext(), newLang)
+                Toast.makeText(context, R.string.pref_language_restart, Toast.LENGTH_SHORT).show()
+                restartApp()
+                true
+            }
+        }
+
+        private fun restartApp() {
+            android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
+                val packageManager = requireContext().packageManager
+                val packageName = requireContext().packageName
+                val intent = packageManager.getLaunchIntentForPackage(packageName)
+                intent?.let {
+                    val flags =
+                        Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                            Intent.FLAG_ACTIVITY_NEW_TASK or
+                            Intent.FLAG_ACTIVITY_CLEAR_TASK
+                    it.addFlags(flags)
+                    it.putExtra("language_changed", true)
+                    startActivity(it)
+                }
+                android.os.Process.killProcess(android.os.Process.myPid())
+                System.exit(0)
+            }, RESTART_DELAY_MS)
+        }
+
+        companion object {
+            private const val RESTART_DELAY_MS = 500L
         }
     }
 }

--- a/app/src/main/java/io/github/domi04151309/home/fragments/HueScenesFragment.kt
+++ b/app/src/main/java/io/github/domi04151309/home/fragments/HueScenesFragment.kt
@@ -68,7 +68,9 @@ class HueScenesFragment :
 
         scenesRequest =
             JsonObjectRequest(
-                Request.Method.GET, lampInterface.addressPrefix + SCENES_PATH, null,
+                Request.Method.GET,
+                lampInterface.addressPrefix + SCENES_PATH,
+                null,
                 this,
             ) { error ->
                 Toast.makeText(

--- a/app/src/main/java/io/github/domi04151309/home/helpers/LocaleHelper.kt
+++ b/app/src/main/java/io/github/domi04151309/home/helpers/LocaleHelper.kt
@@ -1,0 +1,147 @@
+package io.github.domi04151309.home.helpers
+
+import android.app.Activity
+import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.os.Build
+import android.os.LocaleList
+import androidx.core.content.edit
+import androidx.preference.PreferenceManager
+import java.util.Locale
+
+object LocaleHelper {
+    const val PREF_LANGUAGE = "language"
+    const val PREF_LANGUAGE_DEFAULT = ""
+
+    private val SUPPORTED_LANGUAGES =
+        mapOf(
+            "" to "System default",
+            "en" to "English",
+            "ar" to "العربية",
+            "bg" to "Български",
+            "cs" to "Čeština",
+            "da" to "Dansk",
+            "de" to "Deutsch",
+            "el" to "Ελληνικά",
+            "es" to "Español",
+            "et" to "Eesti",
+            "fi" to "Suomi",
+            "fr" to "Français",
+            "hu" to "Magyar",
+            "it" to "Italiano",
+            "ja" to "日本語",
+            "ko" to "한국어",
+            "lt" to "Lietuvių",
+            "lv" to "Latviešu",
+            "nl" to "Nederlands",
+            "pl" to "Polski",
+            "pt" to "Português",
+            "ro" to "Română",
+            "ru" to "Русский",
+            "sv" to "Svenska",
+            "tr" to "Türkçe",
+            "vi" to "Tiếng Việt",
+            "zh-rCN" to "简体中文",
+            "zh-rTW" to "繁體中文",
+        )
+
+    fun getLanguageDisplayName(languageCode: String): String =
+        SUPPORTED_LANGUAGES[languageCode] ?: SUPPORTED_LANGUAGES[PREF_LANGUAGE_DEFAULT]!!
+
+    fun getSupportedLanguages(): Map<String, String> = SUPPORTED_LANGUAGES
+
+    fun getCurrentLanguage(context: Context): String {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        return prefs.getString(PREF_LANGUAGE, PREF_LANGUAGE_DEFAULT) ?: PREF_LANGUAGE_DEFAULT
+    }
+
+    /**
+     * Wraps the context with the saved locale configuration.
+     * This should be called from attachBaseContext() in Application and Activities.
+     */
+    fun wrapContext(context: Context): Context {
+        val language = getCurrentLanguage(context)
+        return if (language.isEmpty()) {
+            // Use system default
+            context
+        } else {
+            wrapContextWithLocale(context, language)
+        }
+    }
+
+    /**
+     * Sets a new locale and saves it to preferences.
+     * Should be called when user changes language in settings.
+     */
+    fun setNewLocale(
+        context: Context,
+        language: String,
+    ) {
+        // Save preference with commit to ensure it's written before restart
+        PreferenceManager.getDefaultSharedPreferences(context).edit {
+            putString(PREF_LANGUAGE, language)
+            commit()
+        }
+    }
+
+    private fun localeForLanguageCode(language: String): Locale =
+        when (language) {
+            "zh-rCN" -> Locale("zh", "CN")
+            "zh-rTW" -> Locale("zh", "TW")
+            else -> Locale(language)
+        }
+
+    private fun wrapContextWithLocale(
+        context: Context,
+        language: String,
+    ): Context {
+        val locale = localeForLanguageCode(language)
+        Locale.setDefault(locale)
+
+        val config = Configuration(context.resources.configuration)
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            val localeList = LocaleList(locale)
+            config.setLocales(localeList)
+            context.createConfigurationContext(config)
+        } else {
+            @Suppress("DEPRECATION")
+            config.locale = locale
+            @Suppress("DEPRECATION")
+            context.resources.updateConfiguration(config, context.resources.displayMetrics)
+            context
+        }
+    }
+
+    /**
+     * Updates the configuration for an activity.
+     * Call this in onCreate() of each activity before setContentView().
+     */
+    fun updateActivityConfiguration(activity: Activity) {
+        val language = getCurrentLanguage(activity)
+        if (language.isEmpty()) return
+
+        val locale = localeForLanguageCode(language)
+        Locale.setDefault(locale)
+        updateConfiguration(activity, locale)
+    }
+
+    private fun updateConfiguration(
+        activity: Activity,
+        locale: Locale,
+    ) {
+        val resources: Resources = activity.resources
+        val config: Configuration = resources.configuration
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            config.setLocales(LocaleList(locale))
+            activity.createConfigurationContext(config)
+        } else {
+            @Suppress("DEPRECATION")
+            config.locale = locale
+            @Suppress("DEPRECATION")
+            resources.updateConfiguration(config, resources.displayMetrics)
+        }
+    }
+}

--- a/app/src/main/java/io/github/domi04151309/home/helpers/P.kt
+++ b/app/src/main/java/io/github/domi04151309/home/helpers/P.kt
@@ -7,4 +7,6 @@ internal object P {
     const val PREF_COLUMNS_DEFAULT = "auto"
     const val PREF_CONTROLS_AUTH = "controls_auth"
     const val PREF_CONTROLS_AUTH_DEFAULT = false
+    const val PREF_LANGUAGE = "language"
+    const val PREF_LANGUAGE_DEFAULT = ""
 }

--- a/app/src/main/java/io/github/domi04151309/home/helpers/SliderUtils.kt
+++ b/app/src/main/java/io/github/domi04151309/home/helpers/SliderUtils.kt
@@ -29,8 +29,10 @@ object SliderUtils {
         gradient.setCornerRadius(dpToPx(view.resources, CORNER_RADIUS).toFloat())
         gradient.paint.shader =
             LinearGradient(
-                0f, 0f,
-                view.width.toFloat(), 0f,
+                0f,
+                0f,
+                view.width.toFloat(),
+                0f,
                 colors,
                 null,
                 Shader.TileMode.CLAMP,

--- a/app/src/main/res/layout/activity_devices.xml
+++ b/app/src/main/res/layout/activity_devices.xml
@@ -1,4 +1,5 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -11,7 +12,8 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:minHeight="?attr/actionBarSize" />
+            android:minHeight="?attr/actionBarSize"
+            app:title="@string/pref_edit" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,4 +1,5 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -11,7 +12,8 @@
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:minHeight="?attr/actionBarSize" />
+            android:minHeight="?attr/actionBarSize"
+            app:title="@string/pref" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">الإعدادات العامة</string>
     <string name="pref_columns">عدد الأعمدة</string>
     <string name="pref_columns_summary">تغيير عدد أعمدة القائمة الرئيسية</string>
+    <string name="pref_language">اللغة</string>
+    <string name="pref_language_summary">اختيار لغة التطبيق</string>
+    <string name="pref_language_restart">جارٍ إعادة تشغيل التطبيق لتطبيق اللغة...</string>
     <string name="pref_devices">الأجهزة</string>
     <string name="pref_edit">تحرير قائمة الأجهزة</string>
     <string name="pref_edit_summary">تحرير قائمة الأجهزة</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>إضافة جهاز بالعنوان</item>
         <item>البحث عن أجهزة متوافقة (تجريبي)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>الإعداد الافتراضي للنظام</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Общи настройки</string>
     <string name="pref_columns">Брой колони</string>
     <string name="pref_columns_summary">Променя броя колони на основния списък</string>
+    <string name="pref_language">Език</string>
+    <string name="pref_language_summary">Изберете езика на приложението</string>
+    <string name="pref_language_restart">Рестартиране на приложението за прилагане на езика...</string>
     <string name="pref_devices">Устройства</string>
     <string name="pref_edit">Редактиране на списъка с устройства</string>
     <string name="pref_edit_summary">Редактирайте списъка с устройства</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Добавяне на устройство по адрес</item>
         <item>Търсене на съвместими устройства (експериментално)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Системна по подразбиране</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Obecná nastavení</string>
     <string name="pref_columns">Počet sloupců</string>
     <string name="pref_columns_summary">Změní počet sloupců hlavního seznamu</string>
+    <string name="pref_language">Jazyk</string>
+    <string name="pref_language_summary">Vyberte jazyk aplikace</string>
+    <string name="pref_language_restart">Restartování aplikace pro aplikování jazyka...</string>
     <string name="pref_devices">Zařízení</string>
     <string name="pref_edit">Upravit seznam zařízení</string>
     <string name="pref_edit_summary">Upravte seznam zařízení</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Přidat zařízení podle adresy</item>
         <item>Hledat kompatibilní zařízení (experimentální)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Výchozí systému</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Generelle indstillinger</string>
     <string name="pref_columns">Antal kolonner</string>
     <string name="pref_columns_summary">Ændrer antallet af kolonner i hovedlisten</string>
+    <string name="pref_language">Sprog</string>
+    <string name="pref_language_summary">Vælg app-sprog</string>
+    <string name="pref_language_restart">Genstarter app for at anvende sprog...</string>
     <string name="pref_devices">Enheder</string>
     <string name="pref_edit">Rediger enhedsliste</string>
     <string name="pref_edit_summary">Rediger listen over enheder</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Tilføj enhed efter adresse</item>
         <item>Søg efter kompatible enheder (eksperimentelt)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Systemstandard</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Generelle Einstellungen</string>
     <string name="pref_columns">Spaltenanzahl</string>
     <string name="pref_columns_summary">Ändert die Anzahl der Spalten der Hauptliste</string>
+    <string name="pref_language">Sprache</string>
+    <string name="pref_language_summary">Wählen Sie die App-Sprache</string>
+    <string name="pref_language_restart">App wird neu gestartet, um Sprache anzuwenden...</string>
     <string name="pref_devices">Geräte</string>
     <string name="pref_edit">Geräteliste bearbeiten</string>
     <string name="pref_edit_summary">Bearbeiten Sie Ihre Geräteliste</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Gerät mit Adresse hinzufügen</item>
         <item>Nach kompatiblen Geräten suchen (experimentell)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Systemstandard</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Γενικές ρυθμίσεις</string>
     <string name="pref_columns">Αριθμός στηλών</string>
     <string name="pref_columns_summary">Αλλάζει τον αριθμό των στηλών της κύριας λίστας</string>
+    <string name="pref_language">Γλώσσα</string>
+    <string name="pref_language_summary">Επιλέξτε τη γλώσσα της εφαρμογής</string>
+    <string name="pref_language_restart">Επανεκκίνηση της εφαρμογής για εφαρμογή της γλώσσας...</string>
     <string name="pref_devices">Συσκευές</string>
     <string name="pref_edit">Επεξεργασία λίστας συσκευών</string>
     <string name="pref_edit_summary">Επεξεργασία της λίστας συσκευών</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Προσθήκη συσκευής με διεύθυνση</item>
         <item>Αναζήτηση συμβατών συσκευών (πειραματικό)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Προεπιλογή συστήματος</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Ajustes generales</string>
     <string name="pref_columns">Número de columnas</string>
     <string name="pref_columns_summary">Cambia el número de columnas de la lista principal</string>
+    <string name="pref_language">Idioma</string>
+    <string name="pref_language_summary">Seleccione el idioma de la aplicación</string>
+    <string name="pref_language_restart">Reiniciando la aplicación para aplicar el idioma...</string>
     <string name="pref_devices">Dispositivos</string>
     <string name="pref_edit">Editar lista de dispositivos</string>
     <string name="pref_edit_summary">Editar la lista de dispositivos</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Añadir dispositivo por dirección</item>
         <item>Buscar dispositivos compatibles (experimental)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Predeterminado del sistema</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Üldised seaded</string>
     <string name="pref_columns">Veergude arv</string>
     <string name="pref_columns_summary">Muudab peamise nimekirja veergude arvu</string>
+    <string name="pref_language">Keel</string>
+    <string name="pref_language_summary">Vali rakenduse keel</string>
+    <string name="pref_language_restart">Rakenduse taaskäivitamine keele rakendamiseks...</string>
     <string name="pref_devices">Seadmed</string>
     <string name="pref_edit">Muuda seadme nimekirja</string>
     <string name="pref_edit_summary">Muuda seadmete nimekirja</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Lisa seade aadressi järgi</item>
         <item>Otsi ühilduvaid seadmeid (katsejärgus)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Süsteemi vaikeseade</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Yleiset asetukset</string>
     <string name="pref_columns">Sarakkeiden määrä</string>
     <string name="pref_columns_summary">Muuttaa päälistan sarakkeiden määrää</string>
+    <string name="pref_language">Kieli</string>
+    <string name="pref_language_summary">Valitse sovelluksen kieli</string>
+    <string name="pref_language_restart">Käynnistetään sovellus uudelleen kielen asettamiseksi...</string>
     <string name="pref_devices">Laitteet</string>
     <string name="pref_edit">Muokkaa laiteluetteloa</string>
     <string name="pref_edit_summary">Muokkaa laitelistaa</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Lisää laite osoitteella</item>
         <item>Etsi yhteensopivia laitteita (kokeellinen)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Järjestelmän oletus</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Paramètres généraux</string>
     <string name="pref_columns">Nombre de colonnes</string>
     <string name="pref_columns_summary">Modifie le nombre de colonnes de la liste principale</string>
+    <string name="pref_language">Langue</string>
+    <string name="pref_language_summary">Sélectionnez la langue de l\'application</string>
+    <string name="pref_language_restart">Redémarrage de l\'application pour appliquer la langue...</string>
     <string name="pref_devices">Appareils</string>
     <string name="pref_edit">Modifier la liste des appareils</string>
     <string name="pref_edit_summary">Modifier la liste des appareils</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Ajouter un appareil par adresse</item>
         <item>Rechercher des appareils compatibles (expérimental)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Valeur par défaut du système</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Általános beállítások</string>
     <string name="pref_columns">Oszlopok száma</string>
     <string name="pref_columns_summary">Megváltoztatja a főlista oszlopainak számát</string>
+    <string name="pref_language">Nyelv</string>
+    <string name="pref_language_summary">Válassza ki az alkalmazás nyelvét</string>
+    <string name="pref_language_restart">Alkalmazás újraindítása a nyelv alkalmazásához...</string>
     <string name="pref_devices">Eszközök</string>
     <string name="pref_edit">Eszközlista szerkesztése</string>
     <string name="pref_edit_summary">Az eszközök listájának szerkesztése</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Eszköz hozzáadása cím alapján</item>
         <item>Kompatibilis eszközök keresése (kísérleti)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Rendszer alapértelmezett</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Impostazioni generali</string>
     <string name="pref_columns">Numero di colonne</string>
     <string name="pref_columns_summary">Modifica il numero di colonne della lista principale</string>
+    <string name="pref_language">Lingua</string>
+    <string name="pref_language_summary">Seleziona la lingua dell\'app</string>
+    <string name="pref_language_restart">Riavvio dell\'app per applicare la lingua...</string>
     <string name="pref_devices">Dispositivi</string>
     <string name="pref_edit">Modifica lista dispositivi</string>
     <string name="pref_edit_summary">Modifica la lista dei dispositivi</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Aggiungi dispositivo per indirizzo</item>
         <item>Cerca dispositivi compatibili (sperimentale)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Predefinito di sistema</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">一般設定</string>
     <string name="pref_columns">列数</string>
     <string name="pref_columns_summary">メインリストの列数を変更</string>
+    <string name="pref_language">言語</string>
+    <string name="pref_language_summary">アプリの言語を選択</string>
+    <string name="pref_language_restart">言語を適用するためにアプリを再起動しています...</string>
     <string name="pref_devices">デバイス</string>
     <string name="pref_edit">デバイスリストを編集</string>
     <string name="pref_edit_summary">デバイスのリストを編集</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>アドレスでデバイスを追加</item>
         <item>互換性のあるデバイスを検索（実験的）</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>システムのデフォルト</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">일반 설정</string>
     <string name="pref_columns">열 수</string>
     <string name="pref_columns_summary">메인 목록의 열 수 변경</string>
+    <string name="pref_language">언어</string>
+    <string name="pref_language_summary">앱 언어 선택</string>
+    <string name="pref_language_restart">언어를 적용하기 위해 앱을 다시 시작하는 중...</string>
     <string name="pref_devices">장치</string>
     <string name="pref_edit">장치 목록 편집</string>
     <string name="pref_edit_summary">장치 목록을 편집합니다</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>주소로 장치 추가</item>
         <item>호환되는 장치 검색 (실험적)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>시스템 기본값</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Bendrieji nustatymai</string>
     <string name="pref_columns">Stulpelių skaičius</string>
     <string name="pref_columns_summary">Keičia pagrindinio sąrašo stulpelių skaičių</string>
+    <string name="pref_language">Kalba</string>
+    <string name="pref_language_summary">Pasirinkite programėlės kalbą</string>
+    <string name="pref_language_restart">Paleidžiama programėlę iš naujo, kad pritaikytų kalbą...</string>
     <string name="pref_devices">Įrenginiai</string>
     <string name="pref_edit">Redaguoti įrenginių sąrašą</string>
     <string name="pref_edit_summary">Redaguoti įrenginių sąrašą</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Pridėti įrenginį pagal adresą</item>
         <item>Ieškoti suderinamų įrenginių (eksperimentinis)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Sistemos numatytasis</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Vispārīgie iestatījumi</string>
     <string name="pref_columns">Kolonnu skaits</string>
     <string name="pref_columns_summary">Maina galvenā saraksta kolonnu skaitu</string>
+    <string name="pref_language">Valoda</string>
+    <string name="pref_language_summary">Izvēlieties lietotnes valodu</string>
+    <string name="pref_language_restart">Lietotnes pārstartēšana, lai piemērotu valodu...</string>
     <string name="pref_devices">Ierīces</string>
     <string name="pref_edit">Rediģēt ierīču sarakstu</string>
     <string name="pref_edit_summary">Rediģēt ierīču sarakstu</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Pievienot ierīci pēc adreses</item>
         <item>Meklēt savietojamas ierīces (eksperimentāli)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Sistēmas noklusējums</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Algemene instellingen</string>
     <string name="pref_columns">Aantal kolommen</string>
     <string name="pref_columns_summary">Wijzigt het aantal kolommen van de hoofdlijst</string>
+    <string name="pref_language">Taal</string>
+    <string name="pref_language_summary">Selecteer de app-taal</string>
+    <string name="pref_language_restart">App opnieuw opstarten om taal toe te passen...</string>
     <string name="pref_devices">Apparaten</string>
     <string name="pref_edit">Apparaatlijst bewerken</string>
     <string name="pref_edit_summary">Bewerk je apparaatlijst</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Apparaat toevoegen met adres</item>
         <item>Zoeken naar compatibele apparaten (experimenteel)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Systeemstandaard</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Ustawienia ogólne</string>
     <string name="pref_columns">Liczba kolumn</string>
     <string name="pref_columns_summary">Zmienia liczbę kolumn głównej listy</string>
+    <string name="pref_language">Język</string>
+    <string name="pref_language_summary">Wybierz język aplikacji</string>
+    <string name="pref_language_restart">Restartowanie aplikacji, aby zastosować język...</string>
     <string name="pref_devices">Urządzenia</string>
     <string name="pref_edit">Edytuj listę urządzeń</string>
     <string name="pref_edit_summary">Edytuj listę urządzeń</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Dodaj urządzenie po adresie</item>
         <item>Wyszukaj kompatybilne urządzenia (eksperymentalne)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Domyślny systemu</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Definições Gerais</string>
     <string name="pref_columns">Número de colunas</string>
     <string name="pref_columns_summary">Altera o número de colunas da lista principal</string>
+    <string name="pref_language">Idioma</string>
+    <string name="pref_language_summary">Selecione o idioma do aplicativo</string>
+    <string name="pref_language_restart">Reiniciando a aplicação para aplicar o idioma...</string>
     <string name="pref_devices">Dispositivos</string>
     <string name="pref_edit">Editar lista de dispositivos</string>
     <string name="pref_edit_summary">Editar a lista de dispositivos</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Adicionar dispositivo por endereço</item>
         <item>Procurar dispositivos compatíveis (experimental)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Padrão do sistema</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Setări generale</string>
     <string name="pref_columns">Număr de coloane</string>
     <string name="pref_columns_summary">Modifică numărul de coloane al listei principale</string>
+    <string name="pref_language">Limbă</string>
+    <string name="pref_language_summary">Selectaţi limba aplicaţiei</string>
+    <string name="pref_language_restart">Se repornește aplicația pentru a aplica limba...</string>
     <string name="pref_devices">Dispozitive</string>
     <string name="pref_edit">Editare listă dispozitive</string>
     <string name="pref_edit_summary">Editați lista de dispozitive</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Adăugați dispozitiv după adresă</item>
         <item>Căutați dispozitive compatibile (experimental)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Implicită sistemului</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Общие настройки</string>
     <string name="pref_columns">Количество столбцов</string>
     <string name="pref_columns_summary">Изменяет количество столбцов главного списка</string>
+    <string name="pref_language">Язык</string>
+    <string name="pref_language_summary">Выберите язык приложения</string>
+    <string name="pref_language_restart">Перезапуск приложения для применения языка...</string>
     <string name="pref_devices">Устройства</string>
     <string name="pref_edit">Изменить список устройств</string>
     <string name="pref_edit_summary">Изменить список устройств</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Добавить устройство по адресу</item>
         <item>Поиск совместимых устройств (экспериментально)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Язык системы</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Allmänna inställningar</string>
     <string name="pref_columns">Antal kolumner</string>
     <string name="pref_columns_summary">Ändrar antalet kolumner i huvudlistan</string>
+    <string name="pref_language">Språk</string>
+    <string name="pref_language_summary">Välj appens språk</string>
+    <string name="pref_language_restart">Startar om appen för att tillämpa språket...</string>
     <string name="pref_devices">Enheter</string>
     <string name="pref_edit">Redigera enhetslista</string>
     <string name="pref_edit_summary">Redigera listan över enheter</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Lägg till enhet efter adress</item>
         <item>Sök efter kompatibla enheter (experimentell)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Systemstandard</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Genel Ayarlar</string>
     <string name="pref_columns">Sutun sayisi</string>
     <string name="pref_columns_summary">Ana listenin sutun sayisini degistirir</string>
+    <string name="pref_language">Dil</string>
+    <string name="pref_language_summary">Uygulama dilini secin</string>
+    <string name="pref_language_restart">Dili uygulamak icin uygulama yeniden baslatiliyor...</string>
     <string name="pref_devices">Cihazlar</string>
     <string name="pref_edit">Cihaz listesini duzenle</string>
     <string name="pref_edit_summary">Cihaz listesini duzenleyin</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Adres ile cihaz ekle</item>
         <item>Uyumlu cihazlari ara (deneysel)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Sistem Varsayilani</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">Cài đặt chung</string>
     <string name="pref_columns">Số cột</string>
     <string name="pref_columns_summary">Thay đổi số cột của danh sách chính</string>
+    <string name="pref_language">Ngôn ngữ</string>
+    <string name="pref_language_summary">Chọn ngôn ngữ ứng dụng</string>
+    <string name="pref_language_restart">Đang khởii động lại ứng dụng để áp dụng ngôn ngữ...</string>
     <string name="pref_devices">Thiết bị</string>
     <string name="pref_edit">Chỉnh sửa danh sách thiết bị</string>
     <string name="pref_edit_summary">Chỉnh sửa danh sách các thiết bị</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>Thêm thiết bị bằng địa chỉ</item>
         <item>Tìm thiết bị tương thích (thử nghiệm)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>Mặc định hệ thống</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">常规设置</string>
     <string name="pref_columns">列数</string>
     <string name="pref_columns_summary">更改主列表的列数</string>
+    <string name="pref_language">语言</string>
+    <string name="pref_language_summary">选择应用语言</string>
+    <string name="pref_language_restart">正在重新启动应用以应用语言...</string>
     <string name="pref_devices">设备</string>
     <string name="pref_edit">编辑设备列表</string>
     <string name="pref_edit_summary">编辑设备列表</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>通过地址添加设备</item>
         <item>搜索兼容设备（实验性）</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>系统默认</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -90,6 +90,9 @@
     <string name="pref_general">一般設定</string>
     <string name="pref_columns">欄數</string>
     <string name="pref_columns_summary">變更主清單的欄數</string>
+    <string name="pref_language">語言</string>
+    <string name="pref_language_summary">選擇應用語言</string>
+    <string name="pref_language_restart">正在重新啟動應用以套用語言...</string>
     <string name="pref_devices">裝置</string>
     <string name="pref_edit">編輯裝置清單</string>
     <string name="pref_edit_summary">編輯裝置清單</string>
@@ -180,5 +183,65 @@
     <string-array name="pref_add_method_array">
         <item>使用位址新增裝置</item>
         <item>搜尋相容裝置（實驗性）</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>系統預設</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,6 +93,9 @@
     <string name="pref_general">General Settings</string>
     <string name="pref_columns">Column count</string>
     <string name="pref_columns_summary">Changes the number of columns of the main list</string>
+    <string name="pref_language">Language</string>
+    <string name="pref_language_summary">Select the app language</string>
+    <string name="pref_language_restart">Restarting app to apply language...</string>
     <string name="pref_devices">Devices</string>
     <string name="pref_edit">Edit device list</string>
     <string name="pref_edit_summary">Edit the list of devices</string>
@@ -192,6 +195,66 @@
     <string-array name="pref_add_method_array">
         <item>Add device by address</item>
         <item>Search for compatible devices (experimental)</item>
+    </string-array>
+    <string-array name="pref_language_array">
+        <item>System default</item>
+        <item>English</item>
+        <item>العربية</item>
+        <item>Български</item>
+        <item>Čeština</item>
+        <item>Dansk</item>
+        <item>Deutsch</item>
+        <item>Ελληνικά</item>
+        <item>Eesti</item>
+        <item>Español</item>
+        <item>Suomi</item>
+        <item>Français</item>
+        <item>Magyar</item>
+        <item>Italiano</item>
+        <item>日本語</item>
+        <item>한국어</item>
+        <item>Lietuvių</item>
+        <item>Latviešu</item>
+        <item>Nederlands</item>
+        <item>Polski</item>
+        <item>Português</item>
+        <item>Română</item>
+        <item>Русский</item>
+        <item>Svenska</item>
+        <item>Türkçe</item>
+        <item>Tiếng Việt</item>
+        <item>简体中文</item>
+        <item>繁體中文</item>
+    </string-array>
+    <string-array name="pref_language_array_values" translatable="false">
+        <item></item>
+        <item>en</item>
+        <item>ar</item>
+        <item>bg</item>
+        <item>cs</item>
+        <item>da</item>
+        <item>de</item>
+        <item>el</item>
+        <item>et</item>
+        <item>es</item>
+        <item>fi</item>
+        <item>fr</item>
+        <item>hu</item>
+        <item>it</item>
+        <item>ja</item>
+        <item>ko</item>
+        <item>lt</item>
+        <item>lv</item>
+        <item>nl</item>
+        <item>pl</item>
+        <item>pt</item>
+        <item>ro</item>
+        <item>ru</item>
+        <item>sv</item>
+        <item>tr</item>
+        <item>vi</item>
+        <item>zh-rCN</item>
+        <item>zh-rTW</item>
     </string-array>
     <string-array name="pref_icons" translatable="false">
         <item>Clock</item>

--- a/app/src/main/res/xml/pref_general.xml
+++ b/app/src/main/res/xml/pref_general.xml
@@ -12,6 +12,15 @@
             app:title="@string/pref_columns"
             app:iconSpaceReserved="false" />
 
+        <ListPreference
+            app:defaultValue=""
+            app:entries="@array/pref_language_array"
+            app:entryValues="@array/pref_language_array_values"
+            app:key="language"
+            app:summary="@string/pref_language_summary"
+            app:title="@string/pref_language"
+            app:iconSpaceReserved="false" />
+
         <SwitchPreference
             app:defaultValue="false"
             app:key="controls_auth"


### PR DESCRIPTION
New translations and language selection section has been added to the app. Please refer to the screenshots.
<img width="1080" height="2408" alt="obraz" src="https://github.com/user-attachments/assets/98f1d81b-9538-4d9d-8214-2f3cf3e57ed7" />
<img width="1080" height="2408" alt="obraz" src="https://github.com/user-attachments/assets/6e0516ea-2891-4c60-9aa2-ac019bb2a0e2" />
<img width="1080" height="2408" alt="obraz" src="https://github.com/user-attachments/assets/1628a85c-9518-4ad4-b00e-222d289d4396" />

Loading screen:

<img width="1080" height="2408" alt="obraz" src="https://github.com/user-attachments/assets/3e61312f-f89d-44b1-a7a9-048babd77735" />
<img width="1080" height="2408" alt="obraz" src="https://github.com/user-attachments/assets/3e96db78-f014-4cf4-9c11-4e263f6a0288" />
