### PR TITLE
Shelly Plus 1 PM power parameter support

### DIFF
--- a/app/src/main/java/io/github/domi04151309/home/api/ShellyAPIParser.kt
+++ b/app/src/main/java/io/github/domi04151309/home/api/ShellyAPIParser.kt
@@ -149,37 +149,52 @@ class ShellyAPIParser(resources: Resources, private val version: Int) :
         val currentId = pm1Config.getInt("id").toString()
         val format = DecimalFormat("#.###")
 
-        listItems +=
-            ListViewItem(
-                title = "${format.format(pm1Status.getDouble("apower"))} W",
-                summary = resources.getString(R.string.shelly_powermeter_summary),
-                hidden = currentId,
-                icon = R.drawable.ic_device_electricity,
-            )
-        listItems +=
-            ListViewItem(
-                title = "${format.format(pm1Status.getDouble("current"))} A",
-                summary = resources.getString(R.string.shelly_powermeter_current),
-                hidden = currentId + "c",
-            )
-        listItems +=
-            ListViewItem(
-                title = "${format.format(pm1Status.getDouble("voltage"))} V",
-                summary = resources.getString(R.string.shelly_powermeter_voltage),
-                hidden = currentId + "v",
-            )
-        listItems +=
-            ListViewItem(
-                title = "${format.format(pm1Status.getJSONObject("aenergy").getDouble("total") / KILO)} kWh",
-                summary = resources.getString(R.string.shelly_powermeter_energy),
-                hidden = currentId + "e",
-            )
-        listItems +=
-            ListViewItem(
-                title = "${format.format(pm1Status.getJSONObject("ret_aenergy").getDouble("total") / KILO)} kWh",
-                summary = resources.getString(R.string.shelly_powermeter_return_energy),
-                hidden = currentId + "rete",
-            )
+        for (statusKey in pm1Status.keys()) {
+            when(statusKey){
+                "apower" -> {
+                    listItems +=
+                        ListViewItem(
+                            title = "${format.format(pm1Status.getDouble("apower"))} W",
+                            summary = resources.getString(R.string.shelly_powermeter_summary),
+                            hidden = currentId,
+                            icon = R.drawable.ic_device_electricity,
+                        )
+                }
+                "current" -> {
+                    listItems +=
+                        ListViewItem(
+                            title = "${format.format(pm1Status.getDouble("current"))} A",
+                            summary = resources.getString(R.string.shelly_powermeter_current),
+                            hidden = currentId + "c",
+                        )
+                }
+                "voltage" -> {
+                    listItems +=
+                        ListViewItem(
+                            title = "${format.format(pm1Status.getDouble("voltage"))} V",
+                            summary = resources.getString(R.string.shelly_powermeter_voltage),
+                            hidden = currentId + "v",
+                        )
+                }
+                "aenergy" -> {
+                    listItems +=
+                        ListViewItem(
+                            title = "${format.format(pm1Status.getJSONObject("aenergy").getDouble("total") / KILO)} kWh",
+                            summary = resources.getString(R.string.shelly_powermeter_energy),
+                            hidden = currentId + "e",
+                        )
+                }
+                "ret_aenergy" -> {
+                    listItems +=
+                        ListViewItem(
+                            title = "${format.format(pm1Status.getJSONObject("ret_aenergy").getDouble("total") / KILO)} kWh",
+                            summary = resources.getString(R.string.shelly_powermeter_return_energy),
+                            hidden = currentId + "rete",
+                        )
+                }
+                else -> {}
+            }
+        }
 
         return listItems
     }

--- a/app/src/main/java/io/github/domi04151309/home/api/ShellyAPIParser.kt
+++ b/app/src/main/java/io/github/domi04151309/home/api/ShellyAPIParser.kt
@@ -121,16 +121,21 @@ class ShellyAPIParser(resources: Resources, private val version: Int) :
     ): List<ListViewItem> {
         val listItems = mutableListOf<ListViewItem>()
         for (switchKey in config.keys()) {
-            if (switchKey.startsWith("switch:")) {
-                listItems.addAll(
-                    parseSwitchV2(
-                        config.getJSONObject(switchKey),
-                        status.getJSONObject(switchKey),
-                        config,
-                    ),
-                )
-            } else if (switchKey.startsWith("pm1:")) {
-                listItems.addAll(parsePowermeter1V2(config.getJSONObject(switchKey), status.getJSONObject(switchKey)))
+            val switchKeyTrim = switchKey.split(":", limit = 2)[0]
+            when(switchKeyTrim) {
+                "switch" -> {
+                    listItems.addAll(
+                        parseSwitchV2(
+                            config.getJSONObject(switchKey),
+                            status.getJSONObject(switchKey),
+                            config,
+                        ),
+                    )
+                }
+                "pm1" -> {
+                    listItems.addAll(parsePowermeter1V2(config.getJSONObject(switchKey), status.getJSONObject(switchKey)))
+                }
+                else -> {}
             }
         }
         return listItems

--- a/app/src/main/java/io/github/domi04151309/home/api/ShellyAPIParser.kt
+++ b/app/src/main/java/io/github/domi04151309/home/api/ShellyAPIParser.kt
@@ -123,17 +123,8 @@ class ShellyAPIParser(resources: Resources, private val version: Int) :
         for (switchKey in config.keys()) {
             val switchKeyTrim = switchKey.split(":", limit = 2)[0]
             when(switchKeyTrim) {
-                "switch" -> {
-                    listItems.addAll(
-                        parseSwitchV2(
-                            config.getJSONObject(switchKey),
-                            status.getJSONObject(switchKey),
-                            config,
-                        ),
-                    )
-                }
-                "pm1" -> {
-                    listItems.addAll(parsePowermeter1V2(config.getJSONObject(switchKey), status.getJSONObject(switchKey)))
+                "switch", "pm1" -> {
+                    listItems.addAll(parseV2(switchKey, config, status))
                 }
                 else -> {}
             }
@@ -141,55 +132,89 @@ class ShellyAPIParser(resources: Resources, private val version: Int) :
         return listItems
     }
 
-    private fun parsePowermeter1V2(
-        pm1Config: JSONObject,
-        pm1Status: JSONObject,
+    private fun parseV2(
+        deviceKey: String,
+        config: JSONObject,
+        status: JSONObject,
     ): List<ListViewItem> {
         val listItems = mutableListOf<ListViewItem>()
-        val currentId = pm1Config.getInt("id").toString()
         val format = DecimalFormat("#.###")
+        val deviceConfig = config.getJSONObject(deviceKey)
+        val deviceStatus = status.getJSONObject(deviceKey)
+        val currentId = deviceConfig.getInt("id")
 
-        for (statusKey in pm1Status.keys()) {
+        for (statusKey in deviceStatus.keys()) {
             when(statusKey){
+                // Switch/Light
+                "output" -> {
+                    val currentState = deviceStatus.getBoolean("output")
+                    listItems +=
+                        ListViewItem(
+                            title =
+                                nameOrDefault(
+                                    if (deviceConfig.isNull("name")) "" else deviceConfig.getString("name"),
+                                    currentId,
+                                ),
+                            summary =
+                                resources.getString(
+                                    if (currentState) {
+                                        R.string.str_on
+                                    } else {
+                                        R.string.str_off
+                                    },
+                                ),
+                            hidden = currentId.toString(),
+                            state = currentState,
+                            icon =
+                                Global.getIcon(
+                                    config.optJSONObject("sys")?.optJSONObject("ui_data")
+                                        ?.optJSONArray("consumption_types")
+                                        ?.getString(currentId)
+                                        ?: "",
+                                    R.drawable.ic_do,
+                                ),
+                        )
+                }
+                // Power meter
                 "apower" -> {
                     listItems +=
                         ListViewItem(
-                            title = "${format.format(pm1Status.getDouble("apower"))} W",
+                            title = "${format.format(deviceStatus.getDouble("apower"))} W",
                             summary = resources.getString(R.string.shelly_powermeter_summary),
-                            hidden = currentId,
+                            hidden = currentId.toString(),
                             icon = R.drawable.ic_device_electricity,
                         )
                 }
                 "current" -> {
                     listItems +=
                         ListViewItem(
-                            title = "${format.format(pm1Status.getDouble("current"))} A",
+                            title = "${format.format(deviceStatus.getDouble("current"))} A",
                             summary = resources.getString(R.string.shelly_powermeter_current),
-                            hidden = currentId + "c",
+                            hidden = currentId.toString() + "c",
                         )
                 }
                 "voltage" -> {
                     listItems +=
                         ListViewItem(
-                            title = "${format.format(pm1Status.getDouble("voltage"))} V",
+                            title = "${format.format(deviceStatus.getDouble("voltage"))} V",
                             summary = resources.getString(R.string.shelly_powermeter_voltage),
-                            hidden = currentId + "v",
+                            hidden = currentId.toString() + "v",
                         )
                 }
                 "aenergy" -> {
                     listItems +=
                         ListViewItem(
-                            title = "${format.format(pm1Status.getJSONObject("aenergy").getDouble("total") / KILO)} kWh",
+                            title = "${format.format(deviceStatus.getJSONObject("aenergy").getDouble("total") / KILO)} kWh",
                             summary = resources.getString(R.string.shelly_powermeter_energy),
-                            hidden = currentId + "e",
+                            hidden = currentId.toString() + "e",
                         )
                 }
                 "ret_aenergy" -> {
                     listItems +=
                         ListViewItem(
-                            title = "${format.format(pm1Status.getJSONObject("ret_aenergy").getDouble("total") / KILO)} kWh",
+                            title = "${format.format(deviceStatus.getJSONObject("ret_aenergy").getDouble("total") / KILO)} kWh",
                             summary = resources.getString(R.string.shelly_powermeter_return_energy),
-                            hidden = currentId + "rete",
+                            hidden = currentId.toString() + "rete",
                         )
                 }
                 else -> {}
@@ -198,45 +223,6 @@ class ShellyAPIParser(resources: Resources, private val version: Int) :
 
         return listItems
     }
-
-    private fun parseSwitchV2(
-        switchConfig: JSONObject,
-        switchStatus: JSONObject,
-        config: JSONObject,
-    ): List<ListViewItem> {
-        val listItems = mutableListOf<ListViewItem>()
-        val currentId = switchConfig.getInt("id")
-        val currentState = switchStatus.getBoolean("output")
-
-        listItems +=
-            ListViewItem(
-                title =
-                    nameOrDefault(
-                        if (switchConfig.isNull("name")) "" else switchConfig.getString("name"),
-                        currentId,
-                    ),
-                summary =
-                    resources.getString(
-                        if (currentState) {
-                            R.string.str_on
-                        } else {
-                            R.string.str_off
-                        },
-                    ),
-                hidden = currentId.toString(),
-                state = currentState,
-                icon =
-                    Global.getIcon(
-                        config.optJSONObject("sys")?.optJSONObject("ui_data")
-                            ?.optJSONArray("consumption_types")
-                            ?.getString(currentId)
-                            ?: "",
-                        R.drawable.ic_do,
-                    ),
-            )
-        return listItems
-    }
-
     private fun nameOrDefault(
         name: String,
         id: Int,

--- a/app/src/test/java/io/github/domi04151309/home/ShellyAPIParserTest.kt
+++ b/app/src/test/java/io/github/domi04151309/home/ShellyAPIParserTest.kt
@@ -137,14 +137,14 @@ class ShellyAPIParserTest {
         assertThat(listItems.size, `is`(5))
 
         var num = 0
-        assertThat(listItems[num].title, `is`("4 W"))
+        assertThat(listItems[num].title, `is`("231.5 V"))
         assertThat(
             listItems[num].summary,
-            `is`(resources.getString(R.string.shelly_powermeter_summary)),
+            `is`(resources.getString(R.string.shelly_powermeter_voltage)),
         )
         assertThat(listItems[num].state, `is`(null as Boolean?))
-        assertThat(listItems[num].hidden, `is`("0"))
-        assertThat(listItems[num].icon, `is`(R.drawable.ic_device_electricity))
+        assertThat(listItems[num].hidden, `is`("0v"))
+        assertThat(listItems[num].icon, `is`(0))
 
         num = 1
         assertThat(listItems[num].title, `is`("0.033 A"))
@@ -157,14 +157,14 @@ class ShellyAPIParserTest {
         assertThat(listItems[num].icon, `is`(0))
 
         num = 2
-        assertThat(listItems[num].title, `is`("231.5 V"))
+        assertThat(listItems[num].title, `is`("4 W"))
         assertThat(
             listItems[num].summary,
-            `is`(resources.getString(R.string.shelly_powermeter_voltage)),
+            `is`(resources.getString(R.string.shelly_powermeter_summary)),
         )
         assertThat(listItems[num].state, `is`(null as Boolean?))
-        assertThat(listItems[num].hidden, `is`("0v"))
-        assertThat(listItems[num].icon, `is`(0))
+        assertThat(listItems[num].hidden, `is`("0"))
+        assertThat(listItems[num].icon, `is`(R.drawable.ic_device_electricity))
 
         num = 3
         assertThat(listItems[num].title, `is`("0.002 kWh"))

--- a/app/src/test/java/io/github/domi04151309/home/ShellyAPIParserTest.kt
+++ b/app/src/test/java/io/github/domi04151309/home/ShellyAPIParserTest.kt
@@ -129,6 +129,65 @@ class ShellyAPIParserTest {
     }
 
     @Test
+    fun parseListItemsJsonV2_shellyPlus1PM() {
+        val configJson = JSONObject(Helpers.getFileContents("/shelly/shelly-plus-1-pm-Shelly.GetConfig.json"))
+        val statusJson = JSONObject(Helpers.getFileContents("/shelly/shelly-plus-1-pm-Shelly.GetStatus.json"))
+
+        val listItems = parserV2.parseResponse(configJson, statusJson)
+        assertThat(listItems.size, `is`(5))
+
+        var num = 0
+        assertThat(listItems[num].title, `is`("Switch 1"))
+        assertThat(
+            listItems[num].summary,
+            `is`(resources.getString(R.string.str_on)),
+        )
+        assertThat(listItems[num].state, `is`(true))
+        assertThat(listItems[num].hidden, `is`("0"))
+        assertThat(listItems[num].icon, `is`(R.drawable.ic_do))
+
+        num = 1
+        assertThat(listItems[num].title, `is`("2738 W"))
+        assertThat(
+            listItems[num].summary,
+            `is`(resources.getString(R.string.shelly_powermeter_summary)),
+        )
+        assertThat(listItems[num].state, `is`(null as Boolean?))
+        assertThat(listItems[num].hidden, `is`("0"))
+        assertThat(listItems[num].icon, `is`(R.drawable.ic_device_electricity))
+
+        num = 2
+        assertThat(listItems[num].title, `is`("217.6 V"))
+        assertThat(
+            listItems[num].summary,
+            `is`(resources.getString(R.string.shelly_powermeter_voltage)),
+        )
+        assertThat(listItems[num].state, `is`(null as Boolean?))
+        assertThat(listItems[num].hidden, `is`("0v"))
+        assertThat(listItems[num].icon, `is`(0))
+
+        num = 3
+        assertThat(listItems[num].title, `is`("12.456 A"))
+        assertThat(
+            listItems[num].summary,
+            `is`(resources.getString(R.string.shelly_powermeter_current)),
+        )
+        assertThat(listItems[num].state, `is`(null as Boolean?))
+        assertThat(listItems[num].hidden, `is`("0c"))
+        assertThat(listItems[num].icon, `is`(0))
+
+        num = 4
+        assertThat(listItems[num].title, `is`("0.017 kWh"))
+        assertThat(
+            listItems[num].summary,
+            `is`(resources.getString(R.string.shelly_powermeter_energy)),
+        )
+        assertThat(listItems[num].state, `is`(null as Boolean?))
+        assertThat(listItems[num].hidden, `is`("0e"))
+        assertThat(listItems[num].icon, `is`(0))
+    }
+
+    @Test
     fun parseListItemsJsonV2_shellyMiniPMG3() {
         val configJson = JSONObject(Helpers.getFileContents("/shelly/shelly-MiniPMG3-Shelly.GetConfig.json"))
         val statusJson = JSONObject(Helpers.getFileContents("/shelly/shelly-MiniPMG3-Shelly.GetStatus.json"))

--- a/app/src/test/resources/shelly/shelly-plus-1-pm-Shelly.GetConfig.json
+++ b/app/src/test/resources/shelly/shelly-plus-1-pm-Shelly.GetConfig.json
@@ -1,0 +1,124 @@
+{
+  "ble": {
+    "enable": false,
+    "rpc": {
+      "enable": false
+    }
+  },
+  "cloud": {
+    "enable": false,
+    "server": "shelly-255-eu.shelly.cloud:6022/jrpc"
+  },
+  "input:0": {
+    "id": 0,
+    "name": null,
+    "type": "switch",
+    "enable": true,
+    "invert": false,
+    "factory_reset": true
+  },
+  "mqtt": {
+    "enable": false,
+    "server": null,
+    "client_id": "shellyplus1pm-123e4cc6badc",
+    "user": null,
+    "ssl_ca": null,
+    "topic_prefix": "shellyplus1pm-123e4cc6badc",
+    "rpc_ntf": true,
+    "status_ntf": false,
+    "use_client_cert": false,
+    "enable_rpc": true,
+    "enable_control": true
+  },
+  "switch:0": {
+    "id": 0,
+    "name": null,
+    "in_mode": "follow",
+    "in_locked": false,
+    "initial_state": "match_input",
+    "auto_on": false,
+    "auto_on_delay": 60.00,
+    "auto_off": false,
+    "auto_off_delay": 60.00,
+    "power_limit": 4480,
+    "voltage_limit": 280,
+    "autorecover_voltage_errors": false,
+    "current_limit": 16.000
+  },
+  "sys": {
+    "device": {
+      "name": null,
+      "mac": "123E4CC6BADC",
+      "fw_id": "20260311-095847/1.7.5-g9979d16",
+      "discoverable": true,
+      "eco_mode": false,
+      "addon_type": null
+    },
+    "location": {
+      "tz": "Europe/Vienna",
+      "lat": 48.186100,
+      "lon": 15.364000
+    },
+    "debug": {
+      "level": 2,
+      "file_level": null,
+      "mqtt": {
+        "enable": false
+      },
+      "websocket": {
+        "enable": false
+      },
+      "udp": {
+        "addr": null
+      }
+    },
+    "ui_data": {},
+    "rpc_udp": {
+      "dst_addr": null,
+      "listen_port": null
+    },
+    "sntp": {
+      "server": "time.cloudflare.com"
+    },
+    "cfg_rev": 14
+  },
+  "wifi": {
+    "ap": {
+      "ssid": "ShellyPlus1PM-123E4CC6BADC",
+      "is_open": true,
+      "enable": false,
+      "range_extender": {
+        "enable": false
+      }
+    },
+    "sta": {
+      "ssid": "asdf",
+      "is_open": false,
+      "enable": true,
+      "ipv4mode": "dhcp",
+      "ip": null,
+      "netmask": null,
+      "gw": null,
+      "nameserver": null
+    },
+    "sta1": {
+      "ssid": null,
+      "is_open": true,
+      "enable": false,
+      "ipv4mode": "dhcp",
+      "ip": null,
+      "netmask": null,
+      "gw": null,
+      "nameserver": null
+    },
+    "roam": {
+      "rssi_thr": -80,
+      "interval": 60
+    }
+  },
+  "ws": {
+    "enable": false,
+    "server": null,
+    "ssl_ca": "ca.pem"
+  }
+}

--- a/app/src/test/resources/shelly/shelly-plus-1-pm-Shelly.GetStatus.json
+++ b/app/src/test/resources/shelly/shelly-plus-1-pm-Shelly.GetStatus.json
@@ -1,0 +1,65 @@
+{
+  "ble": {},
+  "cloud": {
+    "connected": false
+  },
+  "input:0": {
+    "id": 0,
+    "state": false
+  },
+  "mqtt": {
+    "connected": false
+  },
+  "switch:0": {
+    "id": 0,
+    "source": "WS_in",
+    "output": true,
+    "apower": 2738.0,
+    "voltage": 217.6,
+    "current": 12.456,
+    "aenergy": {
+      "total": 16.896,
+      "by_minute": [
+        0.000,
+        0.000,
+        0.000
+      ],
+      "minute_ts": 1778178300
+    },
+    "temperature": {
+      "tC": 61.4,
+      "tF": 142.5
+    }
+  },
+  "sys": {
+    "mac": "123E4CC6BADC",
+    "restart_required": false,
+    "time": "19:33",
+    "unixtime": 1778175183,
+    "last_sync_ts": 1778173786,
+    "uptime": 29954,
+    "ram_size": 250964,
+    "ram_free": 140148,
+    "ram_min_free": 121064,
+    "fs_size": 393216,
+    "fs_free": 131072,
+    "cfg_rev": 14,
+    "kvs_rev": 0,
+    "schedule_rev": 0,
+    "webhook_rev": 0,
+    "btrelay_rev": 0,
+    "available_updates": {},
+    "reset_reason": 3,
+    "utc_offset": 7200
+  },
+  "wifi": {
+    "sta_ip": "10.0.0.99",
+    "status": "got ip",
+    "ssid": "asdf",
+    "bssid": "12:36:26:45:ef:96",
+    "rssi": -64
+  },
+  "ws": {
+    "connected": false
+  }
+}


### PR DESCRIPTION
This adds JSON dumps for the Shelly Plus 1 PM and implements the previously missing power parameter parsing.

I know that the solution is a bit ugly, but I wanted to keep it like this as a base for discussion.
I also looked at the Plus RGBW PM device and there the power properties appear under the "light:" name.
That name space also has a switch state for example for toggling.

I think it might be better to parse all possible properties all the time, since it seems they don't follow any useful scheme.
switch, light and pm can all contain power properties...
If you have a preferred  way to implement this cleanly, I can take a look. :)

Thanks in advance!